### PR TITLE
Unix sockets for http output plugin

### DIFF
--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -11,6 +11,9 @@ data formats.  For data_formats that support batching, metrics are sent in batch
   ## URL is the address to send metrics to
   url = "http://127.0.0.1:8080/telegraf"
 
+  ## Unix Socket is a unix socket serving HTTP to send metrics to
+  # unix_socket = "/var/run/http_server.sock"
+
   ## Timeout for HTTP message
   # timeout = "5s"
 

--- a/plugins/outputs/http/http_unix_test.go
+++ b/plugins/outputs/http/http_unix_test.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixStatusCode(t *testing.T) {
+	ts := httptest.NewUnstartedServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	socket := "./test.sock"
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("Failed to create unix socket: %s", socket)
+	}
+
+	ts.Listener = listener
+	ts.Start()
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", ts.Listener.Addr().String()))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		plugin     *HTTP
+		statusCode int
+		errFunc    func(t *testing.T, err error)
+	}{
+		{
+			name: "success",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusOK,
+			errFunc: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "1xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: 103,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "3xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusMultipleChoices,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "4xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusMultipleChoices,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+
+			serializer := influx.NewSerializer()
+			tt.plugin.SetSerializer(serializer)
+			err = tt.plugin.Connect()
+			require.NoError(t, err)
+
+			err = tt.plugin.Write([]telegraf.Metric{getMetric()})
+			tt.errFunc(t, err)
+		})
+	}
+}


### PR DESCRIPTION
### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

---
Add a unix socket configuration option to the HTTP output plugin.
