### PR TITLE
cherry-pick 1.13 changes to 1.14

### DIFF
--- a/128tech.md
+++ b/128tech.md
@@ -1,0 +1,65 @@
+# Contributions
+
+This README will describe how to modify and build Telegraf for telegraf-128tech.
+
+## Fetching Dependencies
+
+At some point, all of the Telegraf dependencies will need to be pulled down. This will be done during build automatically unless you've already done so and use the flag to skip that step (see "Building a New RPM"). _It's nice to do this manually because there's poor visibility into the build step_.
+
+If you try to run commands without having the dependencies downloaded, you will see errors of the following form.
+
+```
+internal/internal.go:24:2: cannot find package "github.com/alecthomas/units" in any of:
+        /usr/local/go/src/github.com/alecthomas/units (from $GOROOT)
+        /go/src/github.com/alecthomas/units (from $GOPATH)
+```
+
+To fetch dependencies directly, you can do it simply from the shell. See "Using the Shell" for how to get into it. From the shell's default directory, simply run:
+
+```
+dep ensure --vendor-only -v
+```
+
+The above command provides the best visibility. The technically sanctioned fetch step is:
+
+```
+make deps
+```
+
+It does take some time to complete. After that, the dependencies exist in the `vendor` folder and don't need to be fetched again.
+
+## Building a New RPM
+
+Building a new RPM should be straight forward. The necessary building environments exist in the CI docker containers. There is a script `./scripts/docker-env` that wraps docker commands for easy use. To build an RPM from the current source code (example versioning used), simply run:
+
+```
+./scripts/docker-env build --version 1.13.1 --release 2
+```
+
+This will produce new RPMs and place them into the `build` directory.
+
+Fetching can be skipped by using the `--no-fetch` flag:
+
+```
+./scripts/docker-env build --version 1.13.1 --release 3 --no-fetch
+```
+
+## Using the Shell
+
+While not a comprehensive guide, this will get you started. You can drop into the docker environment by running:
+
+```
+./scripts/docker-env shell
+```
+
+From there, you can use `go` and the Telegraf `make` commands as desired. For a few examples, to run all the tests, simply run:
+
+```
+make test
+```
+
+or to run a single plugin's tests, run
+
+```
+go test ./plugins/outputs/http/
+```

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -11,6 +11,9 @@ data formats.  For data_formats that support batching, metrics are sent in batch
   ## URL is the address to send metrics to
   url = "http://127.0.0.1:8080/telegraf"
 
+  ## Unix Socket is a unix socket serving HTTP to send metrics to
+  # unix_socket = "/var/run/http_server.sock"
+
   ## Timeout for HTTP message
   # timeout = "5s"
 

--- a/plugins/outputs/http/http_unix_test.go
+++ b/plugins/outputs/http/http_unix_test.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixStatusCode(t *testing.T) {
+	ts := httptest.NewUnstartedServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	socket := "./test.sock"
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("Failed to create unix socket: %s", socket)
+	}
+
+	ts.Listener = listener
+	ts.Start()
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", ts.Listener.Addr().String()))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		plugin     *HTTP
+		statusCode int
+		errFunc    func(t *testing.T, err error)
+	}{
+		{
+			name: "success",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusOK,
+			errFunc: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "1xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: 103,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "3xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusMultipleChoices,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "4xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusMultipleChoices,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+
+			serializer := influx.NewSerializer()
+			tt.plugin.SetSerializer(serializer)
+			err = tt.plugin.Connect()
+			require.NoError(t, err)
+
+			err = tt.plugin.Write([]telegraf.Metric{getMetric()})
+			tt.errFunc(t, err)
+		})
+	}
+}

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import subprocess
+import os
+import sys
+
+ROOT = pathlib.Path(__file__).parent.parent.resolve()
+SCRIPTS = ROOT / "scripts"
+IMAGE_NAME = "telegraf-build"
+
+
+def main():
+    args = parse_args()
+    create_docker_env(args.docker_file)
+
+    if args.which == "build":
+        build(args)
+    else:
+        shell(args)
+
+
+def build(args):
+    cmd = [] if args.no_fetch else ["make", "deps", "&&"]
+
+    cmd.extend(
+        [
+            f"./scripts/build.py",
+            "--package",
+            "--platform=linux",
+            "--arch=amd64",
+            f"--name={args.name}",
+            f"--version={args.version}",
+            f"--iteration={args.release}",
+            "--release",
+            "--no-get",
+        ]
+    )
+
+    try:
+        cmd = build_docker_command(args.docker_file, ["bash", "-c", " ".join(cmd)])
+
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as error:
+        print("Failed to build the RPM")
+        sys.exit(1)
+
+
+def shell(args):
+    subprocess.run(build_docker_command(args.docker_file, ["bash"], interactive=True))
+
+
+def create_docker_env(docker_file):
+    try:
+        subprocess.check_call(
+            ["docker", "build", "-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
+        )
+    except subprocess.CalledProcessError as error:
+        print("Failed to build the docker image")
+        sys.exit(1)
+
+
+def build_docker_command(docker_file, internal_cmd, interactive=False):
+    cmd = [
+        "docker",
+        "run",
+    ]
+
+    if internal_cmd:
+        cmd.append("-it")
+
+    cmd.extend(
+        [
+            "--rm",
+            "-v",
+            f"{ROOT}:/go/src/github.com/influxdata/telegraf",
+            "-w",
+            "/go/src/github.com/influxdata/telegraf",
+            IMAGE_NAME,
+        ]
+    )
+
+    cmd.extend(internal_cmd)
+    print(" ".join(cmd))
+
+    return cmd
+
+
+def parse_args():
+    arg_parser = argparse.ArgumentParser(
+        description="A docker based environment for building telegraf RPMS",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    subcommands = arg_parser.add_subparsers()
+
+    build_parser = subcommands.add_parser(
+        "build", help="Build an RPM from within the docker environment"
+    )
+
+    shell = subcommands.add_parser(
+        "shell", help="Drop into a shell in the docker environment"
+    )
+
+    ## Build args
+    build_parser.set_defaults(which="build")
+
+    build_parser.add_argument(
+        "--version", help="The version the produced RPM should have", required=True
+    )
+
+    build_parser.add_argument(
+        "--release", help="The release version to use for the RPM", default=1
+    )
+
+    build_parser.add_argument(
+        "--name", help="The name the RPM should have", default="telegraf-128tech"
+    )
+
+    build_parser.add_argument(
+        "--no-fetch",
+        help="Whether to fetch dependencies before building. If not, you should have run `make deps` in your source directory.",
+        action="store_true",
+    )
+
+    ## Shell args
+    shell.set_defaults(which="shell")
+
+    ## Common args
+    arg_parser.add_argument(
+        "--docker-file",
+        help="The docker file to use for the container",
+        default=(SCRIPTS / "ci-1.13.docker"),
+    )
+
+    args = arg_parser.parse_args()
+
+    args.docker_file = str(args.docker_file)
+
+    if not pathlib.Path(args.docker_file).exists():
+        print(f'docker file "{args.docker_file}" does not exist')
+        sys.exit(1)
+
+    return args
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
These changes were made in 1.13, but also need to exist in 1.14.

* allow for unix sockets with the http output plugin
* provide a docker environment/script for building RPMs
