### PR TITLE
Create the t128_metrics input plugin

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -157,6 +157,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/sysstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/system"
 	_ "github.com/influxdata/telegraf/plugins/inputs/systemd_units"
+	_ "github.com/influxdata/telegraf/plugins/inputs/t128_metrics"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tail"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tcp_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/teamspeak"

--- a/plugins/inputs/t128_metrics/README.md
+++ b/plugins/inputs/t128_metrics/README.md
@@ -1,6 +1,6 @@
 # 128T Metrics Input Plugin
 
-The metrics input pluging collects metrics from a 128T instance.
+The metrics input plugin collects metrics from a 128T instance.
 
 ### Configuration
 

--- a/plugins/inputs/t128_metrics/README.md
+++ b/plugins/inputs/t128_metrics/README.md
@@ -1,0 +1,34 @@
+# 128T Metrics Input Plugin
+
+The metrics input pluging collects metrics from a 128T instance.
+
+### Configuration
+
+```toml
+# Read metrics from a 128T instance
+[[inputs.t128_metrics]]
+## Required. The base url for metrics collection
+# base_url = "http://localhost:31517/api/v1/router/Fabric128/"
+
+## A socket to use for retrieving metrics - unused by default
+# unix_socket = "/var/run/128technology/web-server.sock"
+
+## The maximum number of requests to be in flight at once
+# max_simultaneous_requests = 20
+
+## Amount of time allowed to complete a single HTTP request
+# timeout = "5s"
+
+## The metrics to collect
+# [[inputs.t128_metrics.metric]]
+# name = "cpu"
+#
+# [inputs.t128_metrics.metric.fields]
+## Refer to the 128T REST swagger documentation for the list of available metrics
+#     key_name = "stats/<path_to_metric>"
+#     utilization = "stats/cpu/utilization"
+#
+## [inputs.t128_metrics.metric.parameters]
+#     parameter_name = ["value1", "value2"]
+#     core = ["1", "2"]
+```

--- a/plugins/inputs/t128_metrics/api.go
+++ b/plugins/inputs/t128_metrics/api.go
@@ -1,0 +1,50 @@
+package t128_metrics
+
+// RequestMetric describes one element that will need to be retrieved from the back end
+type RequestMetric struct {
+	ID             string
+	Parameters     []RequestParameter
+	OutMeasurement string
+	OutField       string
+}
+
+// RequestParameter is the simple form of a metric's parameters
+type RequestParameter = struct {
+	Name    string   `json:"name"`
+	Values  []string `json:"values,omitempty"`
+	Itemize bool     `json:"itemize"`
+}
+
+// ResponseMetric is a single item in this JSON list
+// [
+//   {
+//     "id": "/stats/active-sources",
+//     "permutations": [
+//       {
+//         "parameters": [
+//           {
+//             "name": "node",
+//             "value": "test1"
+//           }
+//         ],
+//         "value": "0"
+//       }
+//     ]
+//   }
+// ]
+type ResponseMetric struct {
+	ID           string                `json:"id"`
+	Permutations []ResponsePermutation `json:"permutations"`
+}
+
+// ResponsePermutation is a uniquely tagged value within a ResponseMetric
+type ResponsePermutation struct {
+	Parameters []ResponseParameter `json:"parameters"`
+	Value      *string             `json:"value"`
+}
+
+// ResponseParameter describes the format of a parameter produced by the 128T REST API
+type ResponseParameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}

--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -1,0 +1,269 @@
+package t128_metrics
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+// T128Metrics is an input for metrics of a 128T router instance
+type T128Metrics struct {
+	BaseURL                 string             `toml:"base_url"`
+	UnixSocket              string             `toml:"unix_socket"`
+	ConfiguredMetrics       []ConfiguredMetric `toml:"metric"`
+	Timeout                 internal.Duration  `toml:"timeout"`
+	MaxSimultaneousRequests int                `toml:"max_simultaneous_requests"`
+
+	client  *http.Client
+	limiter *requestLimiter
+	metrics []RequestMetric
+}
+
+// ConfiguredMetric represents a single configured metric element
+type ConfiguredMetric struct {
+	Name       string              `toml:"name"`
+	Fields     map[string]string   `toml:"fields"`
+	Parameters map[string][]string `toml:"parameters"`
+}
+
+var sampleConfig = `
+# Read metrics from a 128T instance
+[[inputs.t128_metrics]]
+## Required. The base url for metrics collection
+# base_url = "http://localhost:31517/api/v1/router/Fabric128/"
+
+## A socket to use for retrieving metrics - unused by default
+# unix_socket = "/var/run/128technology/web-server.sock"
+
+## The maximum number of requests to be in flight at once
+# max_simultaneous_requests = 20
+
+## Amount of time allowed to complete a single HTTP request
+# timeout = "5s"
+
+## The metrics to collect
+# [[inputs.t128_metrics.metric]]
+# name = "cpu"
+#
+# [inputs.t128_metrics.metric.fields]
+## Refer to the 128T REST swagger documentation for the list of available metrics
+#     key_name = "stats/<path_to_metric>"
+#     utilization = "stats/cpu/utilization"
+#
+## [inputs.t128_metrics.metric.parameters]
+#     parameter_name = ["value1", "value2"]
+#     core = ["1", "2"]
+`
+
+// SampleConfig returns the default configuration of the Input
+func (*T128Metrics) SampleConfig() string {
+	return sampleConfig
+}
+
+// Description returns a one-sentence description on the Input
+func (*T128Metrics) Description() string {
+	return "Read metrics from a 128T router instance"
+}
+
+// Init sets up the input to be ready for action
+func (plugin *T128Metrics) Init() error {
+	if plugin.BaseURL[len(plugin.BaseURL)-1:] != "/" {
+		plugin.BaseURL += "/"
+	}
+
+	transport := http.DefaultTransport
+
+	if plugin.UnixSocket != "" {
+		transport = &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", plugin.UnixSocket)
+			},
+		}
+	}
+
+	plugin.client = &http.Client{Transport: transport, Timeout: plugin.Timeout.Duration}
+	plugin.limiter = newRequestLimiter(plugin.MaxSimultaneousRequests)
+	plugin.metrics = configuredMetricsToRequestMetrics(plugin.ConfiguredMetrics)
+
+	return nil
+}
+
+// Gather takes in an accumulator and adds the metrics that the Input
+// gathers. This is called every "interval"
+func (plugin *T128Metrics) Gather(acc telegraf.Accumulator) error {
+	timestamp := time.Now().Round(time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(len(plugin.metrics))
+
+	for _, requestMetric := range plugin.metrics {
+		go func(metric RequestMetric) {
+			plugin.retrieveMetric(metric, acc, timestamp)
+			wg.Done()
+		}(requestMetric)
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func (plugin *T128Metrics) retrieveMetric(metric RequestMetric, acc telegraf.Accumulator, timestamp time.Time) {
+	request, err := plugin.createRequest(plugin.BaseURL, metric)
+	if err != nil {
+		acc.AddError(fmt.Errorf("failed to create a request for metric %s: %w", metric.ID, err))
+		return
+	}
+
+	plugin.limiter.wait()
+	response, err := plugin.client.Do(request)
+	plugin.limiter.done()
+
+	if err != nil {
+		acc.AddError(fmt.Errorf("failed to retrieve metric %s: %w", metric.ID, err))
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		message, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			message = []byte("")
+		}
+
+		acc.AddError(fmt.Errorf("status code %d not OK for metric %s: %s", response.StatusCode, metric.ID, message))
+		return
+	}
+
+	var responseMetrics []ResponseMetric
+	if err := json.NewDecoder(response.Body).Decode(&responseMetrics); err != nil {
+		acc.AddError(fmt.Errorf("failed to decode response for metric %s: %w", metric.ID, err))
+		return
+	}
+
+	for _, responseMetric := range responseMetrics {
+		for _, permutation := range responseMetric.Permutations {
+			if permutation.Value == nil {
+				continue
+			}
+
+			tags := make(map[string]string)
+			for _, parameter := range permutation.Parameters {
+				tags[parameter.Name] = parameter.Value
+			}
+
+			acc.AddFields(
+				metric.OutMeasurement,
+				map[string]interface{}{metric.OutField: tryNumericConversion(*permutation.Value)},
+				tags,
+				timestamp)
+		}
+	}
+}
+
+func (plugin *T128Metrics) createRequest(baseURL string, metric RequestMetric) (*http.Request, error) {
+	content := struct {
+		Parameters []RequestParameter `json:"parameters,omitempty"`
+	}{
+		metric.Parameters,
+	}
+
+	body, err := json.Marshal(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request body for metric '%s': %w", metric.ID, err)
+	}
+
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for metric '%s': %w", metric.ID, err)
+	}
+
+	return request, nil
+}
+
+func configuredMetricsToRequestMetrics(configuredMetrics []ConfiguredMetric) []RequestMetric {
+	requestMetrics := make([]RequestMetric, 0)
+
+	for _, configMetric := range configuredMetrics {
+		for fieldName, fieldPath := range configMetric.Fields {
+			// Sort names for consistency in testing. It's not free, but only happens during startup.
+			parameterNames := make([]string, 0, len(configMetric.Parameters))
+			for parameterName := range configMetric.Parameters {
+				parameterNames = append(parameterNames, parameterName)
+			}
+			sort.Strings(parameterNames)
+
+			parameters := make([]RequestParameter, 0, len(configMetric.Parameters))
+			for _, parameterName := range parameterNames {
+				values := configMetric.Parameters[parameterName]
+				parameters = append(parameters, RequestParameter{
+					Name:    parameterName,
+					Values:  values,
+					Itemize: true,
+				})
+			}
+
+			requestMetrics = append(requestMetrics, RequestMetric{
+				ID:             fieldPath,
+				Parameters:     parameters,
+				OutMeasurement: configMetric.Name,
+				OutField:       fieldName,
+			})
+		}
+	}
+
+	return requestMetrics
+}
+
+func tryNumericConversion(value string) interface{} {
+	if i, err := strconv.Atoi(value); err == nil {
+		return i
+	} else if f, err := strconv.ParseFloat(value, 64); err == nil {
+		return f
+	} else {
+		return value
+	}
+}
+
+type requestLimiter struct {
+	synchronizer chan struct{}
+}
+
+func newRequestLimiter(limit int) *requestLimiter {
+	limiter := &requestLimiter{make(chan struct{}, limit)}
+
+	for i := 0; i < limit; i++ {
+		limiter.done()
+	}
+
+	return limiter
+}
+
+func (l *requestLimiter) wait() {
+	<-l.synchronizer
+}
+
+func (l *requestLimiter) done() {
+	l.synchronizer <- struct{}{}
+}
+
+func init() {
+	inputs.Add("t128_metrics", func() telegraf.Input {
+		return &T128Metrics{
+			Timeout:                 internal.Duration{Duration: time.Second * 5},
+			MaxSimultaneousRequests: 20,
+		}
+	})
+}

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -1,0 +1,512 @@
+package t128_metrics_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	plugin "github.com/influxdata/telegraf/plugins/inputs/t128_metrics"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type Endpoint struct {
+	URL             string
+	Code            int
+	ExpectedRequest string
+	Response        string
+}
+
+var ResponseProcessingTestCases = []struct {
+	Name              string
+	ConfiguredMetrics []plugin.ConfiguredMetric
+	Endpoints         []Endpoint
+	ExpectedMetrics   []*testutil.Metric
+	ExpectedErrors    []string
+}{
+	{
+		Name: "empty results produce no metrics",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints:       []Endpoint{{"/stats/test", 200, "{}", "[]"}},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  nil,
+	},
+	{
+		Name: "none value produces no metric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": null
+			}]
+		}]`}},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  nil,
+	},
+	{
+		Name: "forms string value if it is non numeric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "test-string"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": "test-string"},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "forms int value if it is numeric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "forms float value if it is numeric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50.5"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50.5},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "adds permutation parameters to metrics",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [
+					{
+						"name": "node",
+						"value": "node1"
+					},
+					{
+						"name": "interface",
+						"value": "intf1"
+					}
+				],
+				"value": "0"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node1", "interface": "intf1"},
+				Fields:      map[string]interface{}{"test-field": 0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "produces multiple metrics for multiple permutations",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test",
+			"permutations": [
+				{
+					"parameters": [
+						{
+							"name": "node",
+							"value": "node1"
+						}
+					],
+					"value": "897"
+				},
+				{
+					"parameters": [
+						{
+							"name": "node",
+							"value": "node2"
+						}
+					],
+					"value": "306"
+				}
+			]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node1"},
+				Fields:      map[string]interface{}{"test-field": 897},
+			},
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node2"},
+				Fields:      map[string]interface{}{"test-field": 306},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "hits multiple endpoints",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}, {
+			"another-test-metric",
+			map[string]string{"another-test-field": "stats/another/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50"
+			}]
+		}]`}, {
+			"/stats/another/test", 200, "{}", `[{
+			"id": "/stats/another/test",
+			"permutations": [{
+				"parameters": [],
+				"value": "60"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+			{
+				Measurement: "another-test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"another-test-field": 60},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "propogates errors to accumulator",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"404",
+			map[string]string{"field": "stats/404"},
+			map[string][]string{},
+		}, {
+			"300",
+			map[string]string{"field": "stats/300"},
+			map[string][]string{},
+		}, {
+			"invalid-json",
+			map[string]string{"field": "stats/invalid-json"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{
+			{"/stats/404", 404, "{}", `it's not right`},
+			{"/stats/300", 300, "{}", `it's not right`},
+			{"/stats/invalid-json", 200, "{}", `{"test": }`},
+		},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"status code 404 not OK for metric stats/404: it's not right",
+			"status code 300 not OK for metric stats/300: it's not right",
+			"failed to decode response for metric stats/invalid-json: invalid character '}' looking for beginning of value",
+		},
+	},
+	{
+		Name: "mixes errors and valid results",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"404",
+			map[string]string{"field": "stats/404"},
+			map[string][]string{},
+		}, {
+			"test-metric",
+			map[string]string{"field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{
+			{"/stats/404", 404, "{}", `it's not right`},
+			{"/stats/test", 200, "{}", `[{
+				"id": "/stats/test-metric",
+				"permutations": [{
+					"parameters": [],
+					"value": "50"
+				}]
+			}]`},
+		},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"field": 50},
+			},
+		},
+		ExpectedErrors: []string{
+			"status code 404 not OK for metric stats/404: it's not right",
+		},
+	},
+}
+
+var RequestFormationTestCases = []struct {
+	Name              string
+	ConfiguredMetrics []plugin.ConfiguredMetric
+	Endpoints         []Endpoint
+}{
+	{
+		Name: "empty request body with no parameters",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", "[]"}},
+	},
+	{
+		Name: "itemizes with no filter values for empty list",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{"interface": {}},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, `{"parameters": [{"name": "interface", "itemize": true}]}`, "[]"}},
+	},
+	{
+		Name: "includes parameter filter values",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{"interface": {"intf1", "intf2"}},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, `{
+				"parameters": [
+					{"name": "interface", "values": ["intf1", "intf2"], "itemize": true}
+				]
+			}`,
+			"[]"}},
+	},
+	{
+		Name: "includes multiple parameter filters",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{
+				"interface": {"intf1", "intf2"},
+				"node":      {"node1", "node2"},
+				"other":     {}},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, `{
+				"parameters": [
+					{"name": "interface", "values": ["intf1", "intf2"], "itemize": true},
+					{"name": "node", "values": ["node1", "node2"], "itemize": true},
+					{"name": "other", "itemize": true}
+				]
+			}`,
+			"[]"}},
+	},
+}
+
+func TestT128MetricsResponseProcessing(t *testing.T) {
+	for _, testCase := range ResponseProcessingTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			fakeServer := createTestServer(t, testCase.Endpoints)
+			defer fakeServer.Close()
+
+			plugin := &plugin.T128Metrics{
+				BaseURL:                 fakeServer.URL,
+				MaxSimultaneousRequests: 20,
+				ConfiguredMetrics:       testCase.ConfiguredMetrics,
+			}
+
+			var acc testutil.Accumulator
+			plugin.Init()
+
+			plugin.Gather(&acc)
+
+			var errorStrings []string = nil
+			for _, err := range acc.Errors {
+				errorStrings = append(errorStrings, err.Error())
+			}
+
+			require.ElementsMatch(t, testCase.ExpectedErrors, errorStrings)
+
+			// Timestamps aren't important, but need to match
+			for _, m := range acc.Metrics {
+				m.Time = time.Time{}
+			}
+
+			// Avoid specifying this unused type for each field
+			for _, m := range testCase.ExpectedMetrics {
+				m.Type = telegraf.Untyped
+			}
+
+			require.ElementsMatch(t, testCase.ExpectedMetrics, acc.Metrics)
+		})
+	}
+}
+
+func TestT128MetricsRequestFormation(t *testing.T) {
+	for _, testCase := range RequestFormationTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			fakeServer := createTestServer(t, testCase.Endpoints)
+			defer fakeServer.Close()
+
+			plugin := &plugin.T128Metrics{
+				BaseURL:                 fakeServer.URL,
+				MaxSimultaneousRequests: 20,
+				ConfiguredMetrics:       testCase.ConfiguredMetrics,
+			}
+
+			var acc testutil.Accumulator
+			plugin.Init()
+
+			require.NoError(t, acc.GatherError(plugin.Gather))
+		})
+	}
+}
+
+func TestT128MetricsErrorResponses(t *testing.T) {
+	for _, testCase := range RequestFormationTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			fakeServer := createTestServer(t, testCase.Endpoints)
+			defer fakeServer.Close()
+
+			plugin := &plugin.T128Metrics{
+				BaseURL:                 fakeServer.URL,
+				MaxSimultaneousRequests: 20,
+				ConfiguredMetrics:       testCase.ConfiguredMetrics,
+			}
+
+			var acc testutil.Accumulator
+			plugin.Init()
+
+			require.NoError(t, acc.GatherError(plugin.Gather))
+		})
+	}
+}
+
+func TestT128MetricsRequestLimiting(t *testing.T) {
+	inFlight := int32(0)
+	const limit = 3
+	const metricCount = 20
+
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		currentInFlight := atomic.AddInt32(&inFlight, 1)
+		defer atomic.AddInt32(&inFlight, -1)
+
+		fmt.Println(currentInFlight)
+		require.LessOrEqual(t, currentInFlight, int32(limit))
+
+		time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+		w.Write([]byte("[]"))
+	}))
+
+	configuredMetrics := make([]plugin.ConfiguredMetric, 0, metricCount)
+	for i := 0; i < metricCount; i++ {
+		configuredMetrics = append(configuredMetrics, plugin.ConfiguredMetric{
+			fmt.Sprintf("test-metric-%d", i),
+			map[string]string{"test-field": fmt.Sprintf("stats/test/%d", i)},
+			map[string][]string{},
+		})
+	}
+
+	plugin := &plugin.T128Metrics{
+		BaseURL:                 fakeServer.URL,
+		MaxSimultaneousRequests: limit,
+		ConfiguredMetrics:       configuredMetrics,
+	}
+
+	var acc testutil.Accumulator
+	plugin.Init()
+
+	require.NoError(t, acc.GatherError(plugin.Gather))
+}
+
+func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
+	endpoints := make(map[string]Endpoint)
+	for _, endpoint := range e {
+		endpoints[endpoint.URL] = endpoint
+	}
+
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		endpoint, ok := endpoints[r.URL.Path]
+		if !ok {
+			w.WriteHeader(404)
+			return
+		}
+
+		if endpoint.ExpectedRequest != "" {
+			contents, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(500)
+				return
+			}
+
+			require.JSONEq(t, endpoint.ExpectedRequest, string(contents), "Unexpected request body for endpoint %s", endpoint.URL)
+		}
+
+		w.WriteHeader(endpoint.Code)
+		w.Write([]byte(endpoint.Response))
+	}))
+
+	return fakeServer
+}


### PR DESCRIPTION
### Create at t128_metrics input plugin

This plugin will collect metrics from a 128T router and publish. It is expected to be running on the system in such a way that no authentication is necessary.

It must be configured the the base stats URL and the metrics of interest. 

### Testing

I've added unit tests covering the functionality and have manually verified that it collects metrics from a running 128T.