### PR TITLE
Add a release workflow for simpler RPM building on release

### DIFF
--- a/.github/actions/Dockerfile
+++ b/.github/actions/Dockerfile
@@ -1,0 +1,1 @@
+../../scripts/ci-1.13.docker

--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -1,0 +1,17 @@
+name: Build telegraf RPMs
+description: A simple way to build telegraf RPMs within a container
+inputs:
+  version:
+    description: What version to use for the RPMs
+    required: true
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ./scripts/build.py
+    - --package
+    - --platform=linux
+    - --arch=amd64
+    - --name=telegraf-128tech
+    - --version=${{ inputs.version }}
+    - --release

--- a/.github/workflows/ci-128tech.yaml
+++ b/.github/workflows/ci-128tech.yaml
@@ -5,9 +5,11 @@ on:
     branches: [release-128tech-*]
   pull_request:
     branches: [release-128tech-*]
+  release:
+    tags: [128tech-v*]
 
 jobs:
-  build:
+  test:
     name: Continuous Integration
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-128tech.yaml
+++ b/.github/workflows/release-128tech.yaml
@@ -1,0 +1,30 @@
+name: Release pipeline for 128tech RPMs
+
+on:
+  release:
+    tags: [128tech-v*]
+
+jobs:
+  build:
+    name: Build RPMs
+    runs-on: ubuntu-latest
+    env:
+      VERSION_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Extract the version from the tag name
+        # tag expected to be of the form 128tech-v<version-number>
+        run: echo "::set-env name=VERSION::${VERSION_TAG:9}"
+
+      - name: Build some RPMs
+        uses: ./.github/actions
+        with:
+          version: ${{ env.VERSION }}
+
+      - name: Upload RPMs as Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: telegraf-128tech-${{ env.VERSION }}.x86_64.rpm
+          path: build/telegraf-128tech-*.x86_64.rpm


### PR DESCRIPTION
## Description

This workflow will allow a user to publish a release with a tag of the form `128tech-v<version-number>` and have CI run along with a build action that will produce the RPM as an artifact. This should make the release process simpler.

I also expect this to be improved in the future such that pushing a valid version tag to a release branch will cause a release to be created with the RPM and with CI having been run. I'm not quite there yet. 

## Testing

I've run quite a few tests on this by creating and deleting releases. You can check the history if you like :) 
