### PR TITLE
Account for patch in version tag

### DIFF
--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -4,6 +4,9 @@ inputs:
   version:
     description: What version to use for the RPMs
     required: true
+  patch:
+    description: The patch of the version (e.g. 1 for -1 or 2 for -2)
+    required: true
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -14,4 +17,5 @@ runs:
     - --arch=amd64
     - --name=telegraf-128tech
     - --version=${{ inputs.version }}
+    - --iteration=${{ inputs.iteration }}
     - --release

--- a/.github/scripts/set_version_environment_variables.sh
+++ b/.github/scripts/set_version_environment_variables.sh
@@ -1,0 +1,17 @@
+echo "VERSION_TAG=$VERSION_TAG"
+
+VERSION_REGEX='^128tech-v([0-9]+\.[0-9]+\.[0-9]+)(-([0-9]+))?$'
+[[ $VERSION_TAG =~ $VERSION_REGEX ]]
+
+if [ -z $BASH_REMATCH ]; then
+    echo "The tagged version does not match the required expression: $VERSION_EXPRESION"
+    exit 1
+fi
+
+echo "::set-env name=VERSION::${BASH_REMATCH[1]}"
+
+if [ ! -z ${BASH_REMATCH[3]} ]; then
+    echo "::set-env name=VERSION_PATCH::${BASH_REMATCH[3]}"
+else
+    echo "::set-env name=VERSION_PATCH::1"
+fi

--- a/.github/workflows/ci-128tech.yaml
+++ b/.github/workflows/ci-128tech.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [release-128tech-*]
   release:
+    types: [published]
     tags: [128tech-v*]
 
 jobs:

--- a/.github/workflows/release-128tech.yaml
+++ b/.github/workflows/release-128tech.yaml
@@ -2,6 +2,7 @@ name: Release pipeline for 128tech RPMs
 
 on:
   release:
+    types: [published]
     tags: [128tech-v*]
 
 jobs:
@@ -14,14 +15,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Extract the version from the tag name
-        # tag expected to be of the form 128tech-v<version-number>
-        run: echo "::set-env name=VERSION::${VERSION_TAG:9}"
+      - name: Extract the version information from the tag name
+        run: bash .github/scripts/set_version_environment_variables.sh
 
       - name: Build some RPMs
         uses: ./.github/actions
         with:
           version: ${{ env.VERSION }}
+          patch: ${{ env.VERSION_PATCH }}
 
       - name: Upload RPMs as Artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
## Description

The build script did not handle the directly provided `-X` patch version in a `128tech-vX.X.X-X` tag. I'm adding a simple bash (as if that exists) script to apply a regex to the tag, separate the version from the patch, and then provide that for use in the build script.

I also threw in a restriction of the release pipeline so creating a release doesn't trigger multiple instances of CI and RPM building.

This is in response to the last RPM being produced as `telegraf-128tech-1.14.4_2-1.x86_64.rpm`