### PR TITLE
Include Content-Type in t128_metrics HTTP requests

### DIFF
--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -200,10 +200,12 @@ func (plugin *T128Metrics) createRequest(baseURL string, metric RequestMetric) (
 		return nil, fmt.Errorf("failed to create request body for metric '%s': %w", metric.ID, err)
 	}
 
-	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewBuffer(body))
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for metric '%s': %w", metric.ID, err)
 	}
+
+	request.Header.Add("Content-Type", "application/json")
 
 	return request, nil
 }

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -557,6 +557,9 @@ func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "POST", r.Method)
+
 		endpoint, ok := endpoints[r.URL.Path]
 		if !ok {
 			w.WriteHeader(404)


### PR DESCRIPTION
## Description

Added the `Content-Type` header as it should have been to start with. Without that header, the request body was not being forwarded.

## Testing

- Added unit tests
- Deployed and verified using existing system tests
