### PR TITLE
Update t128_metrics integer conversion to be optional

### DIFF
--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -32,6 +32,7 @@ type T128Metrics struct {
 	ConfiguredMetrics       []ConfiguredMetric `toml:"metric"`
 	Timeout                 internal.Duration  `toml:"timeout"`
 	MaxSimultaneousRequests int                `toml:"max_simultaneous_requests"`
+	UseIntegerConversion    bool               `toml:"use_integer_conversion"`
 
 	client  *http.Client
 	limiter *requestLimiter
@@ -56,6 +57,9 @@ var sampleConfig = `
 
 ## The maximum number of requests to be in flight at once
 # max_simultaneous_requests = 20
+
+## Whether to attempt conversion of values to integer before conversion to float
+# use_integer_conversion = false
 
 ## Amount of time allowed to complete a single HTTP request
 # timeout = "5s"
@@ -181,7 +185,10 @@ func (plugin *T128Metrics) retrieveMetric(metric RequestMetric, acc telegraf.Acc
 
 			acc.AddFields(
 				metric.OutMeasurement,
-				map[string]interface{}{metric.OutField: tryNumericConversion(*permutation.Value)},
+				map[string]interface{}{metric.OutField: tryNumericConversion(
+					plugin.UseIntegerConversion,
+					*permutation.Value),
+				},
 				tags,
 				timestamp)
 		}
@@ -244,14 +251,18 @@ func configuredMetricsToRequestMetrics(configuredMetrics []ConfiguredMetric) []R
 	return requestMetrics
 }
 
-func tryNumericConversion(value string) interface{} {
-	if i, err := strconv.Atoi(value); err == nil {
-		return i
-	} else if f, err := strconv.ParseFloat(value, 64); err == nil {
-		return f
-	} else {
-		return value
+func tryNumericConversion(useIntegerConversion bool, value string) interface{} {
+	if useIntegerConversion {
+		if i, err := strconv.Atoi(value); err == nil {
+			return i
+		}
 	}
+
+	if f, err := strconv.ParseFloat(value, 64); err == nil {
+		return f
+	}
+
+	return value
 }
 
 type requestLimiter struct {
@@ -281,6 +292,7 @@ func init() {
 		return &T128Metrics{
 			Timeout:                 internal.Duration{Duration: DefaultRequestTimeout},
 			MaxSimultaneousRequests: DefaultMaxSimultaneousRequests,
+			UseIntegerConversion:    false,
 		}
 	})
 }


### PR DESCRIPTION
## Description

The plugin has been converting to integer from the string values of the REST interface. However, the prior behavior was to always convert to float. This change adds a configuration field for whether or not that integer conversion should be attempted.

## Testing

- Unit tests
- Manual verification

```
$ cat /var/lib/128t-monitoring/config/t128_metrics.conf
[global_tags]
host = "${HOSTNAME}"

[agent]
interval = 1
flush_interval = 1

[inputs]
[[inputs.t128_metrics]]
base_url = "http://<removed>/api/v1/router/combo1/"
# use_integer_conversion = true

...

$ ./telegraf --config /var/lib/128t-monitoring/config/t128_metrics.conf --test
2020-06-30T17:08:52Z I! Starting Telegraf
> device-interface,device-interface=test1.11,host=t143-dut1.openstacklocal bandwidth-transmitted=114932016 1593536933000000000
> device-interface,device-interface=test1.<InternalApplication>,host=t143-dut1.openstacklocal bandwidth-transmitted=114932016 1593536933000000000

...

$ vi /var/lib/128t-monitoring/config/t128_metrics.conf
$ cat /var/lib/128t-monitoring/config/t128_metrics.conf
[global_tags]
host = "${HOSTNAME}"

[agent]
interval = 1
flush_interval = 1

[inputs]
[[inputs.t128_metrics]]
base_url = "http://<removed>/api/v1/router/combo1/"
use_integer_conversion = true

...

$ ./telegraf --config /var/lib/128t-monitoring/config/t128_metrics.conf --test
2020-06-30T17:09:08Z I! Starting Telegraf
> device-interface,device-interface=test1.11,host=t143-dut1.openstacklocal bandwidth-transmitted=114938044i 1593536948000000000
> device-interface,device-interface=test1.<InternalApplication>,host=t143-dut1.openstacklocal bandwidth-transmitted=114938044i 1593536948000000000

...

```