### PR TITLE
Cherry pick 128tech 1.14 changes to 1.16

### DIFF
--- a/.github/actions/Dockerfile
+++ b/.github/actions/Dockerfile
@@ -1,0 +1,1 @@
+../../scripts/ci-1.13.docker

--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -1,0 +1,17 @@
+name: Build telegraf RPMs
+description: A simple way to build telegraf RPMs within a container
+inputs:
+  version:
+    description: What version to use for the RPMs
+    required: true
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  args:
+    - ./scripts/build.py
+    - --package
+    - --platform=linux
+    - --arch=amd64
+    - --name=telegraf-128tech
+    - --version=${{ inputs.version }}
+    - --release

--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -4,6 +4,9 @@ inputs:
   version:
     description: What version to use for the RPMs
     required: true
+  patch:
+    description: The patch of the version (e.g. 1 for -1 or 2 for -2)
+    required: true
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -14,4 +17,5 @@ runs:
     - --arch=amd64
     - --name=telegraf-128tech
     - --version=${{ inputs.version }}
+    - --iteration=${{ inputs.iteration }}
     - --release

--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -17,5 +17,5 @@ runs:
     - --arch=amd64
     - --name=telegraf-128tech
     - --version=${{ inputs.version }}
-    - --iteration=${{ inputs.iteration }}
+    - --iteration=${{ inputs.patch }}
     - --release

--- a/.github/scripts/set_version_environment_variables.sh
+++ b/.github/scripts/set_version_environment_variables.sh
@@ -1,0 +1,17 @@
+echo "VERSION_TAG=$VERSION_TAG"
+
+VERSION_REGEX='^128tech-v([0-9]+\.[0-9]+\.[0-9]+)(-([0-9]+))?$'
+[[ $VERSION_TAG =~ $VERSION_REGEX ]]
+
+if [ -z $BASH_REMATCH ]; then
+    echo "The tagged version does not match the required expression: $VERSION_EXPRESION"
+    exit 1
+fi
+
+echo "::set-env name=VERSION::${BASH_REMATCH[1]}"
+
+if [ ! -z ${BASH_REMATCH[3]} ]; then
+    echo "::set-env name=VERSION_PATCH::${BASH_REMATCH[3]}"
+else
+    echo "::set-env name=VERSION_PATCH::1"
+fi

--- a/.github/workflows/ci-128tech.yaml
+++ b/.github/workflows/ci-128tech.yaml
@@ -1,0 +1,35 @@
+name: CI for 128tech branches
+
+on:
+  push:
+    branches: [release-128tech-*]
+  pull_request:
+    branches: [release-128tech-*]
+
+jobs:
+  build:
+    name: Continuous Integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: |
+          go get -v -t -d ./...
+          if [ -f Gopkg.toml ]; then
+              curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+              dep ensure
+          fi
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -short ./...

--- a/.github/workflows/ci-128tech.yaml
+++ b/.github/workflows/ci-128tech.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [release-128tech-*]
   release:
+    types: [published]
     tags: [128tech-v*]
 
 jobs:

--- a/.github/workflows/ci-128tech.yaml
+++ b/.github/workflows/ci-128tech.yaml
@@ -14,10 +14,10 @@ jobs:
     name: Continuous Integration
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.15.2
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.15.2
         id: go
 
       - name: Check out code into the Go module directory
@@ -30,9 +30,6 @@ jobs:
               curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
               dep ensure
           fi
-
-      - name: Build
-        run: go build ./...
 
       - name: Test
         run: go test -short ./...

--- a/.github/workflows/ci-128tech.yaml
+++ b/.github/workflows/ci-128tech.yaml
@@ -5,9 +5,11 @@ on:
     branches: [release-128tech-*]
   pull_request:
     branches: [release-128tech-*]
+  release:
+    tags: [128tech-v*]
 
 jobs:
-  build:
+  test:
     name: Continuous Integration
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-128tech.yaml
+++ b/.github/workflows/release-128tech.yaml
@@ -2,6 +2,7 @@ name: Release pipeline for 128tech RPMs
 
 on:
   release:
+    types: [published]
     tags: [128tech-v*]
 
 jobs:
@@ -14,14 +15,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Extract the version from the tag name
-        # tag expected to be of the form 128tech-v<version-number>
-        run: echo "::set-env name=VERSION::${VERSION_TAG:9}"
+      - name: Extract the version information from the tag name
+        run: bash .github/scripts/set_version_environment_variables.sh
 
       - name: Build some RPMs
         uses: ./.github/actions
         with:
           version: ${{ env.VERSION }}
+          patch: ${{ env.VERSION_PATCH }}
 
       - name: Upload RPMs as Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release-128tech.yaml
+++ b/.github/workflows/release-128tech.yaml
@@ -1,0 +1,30 @@
+name: Release pipeline for 128tech RPMs
+
+on:
+  release:
+    tags: [128tech-v*]
+
+jobs:
+  build:
+    name: Build RPMs
+    runs-on: ubuntu-latest
+    env:
+      VERSION_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Extract the version from the tag name
+        # tag expected to be of the form 128tech-v<version-number>
+        run: echo "::set-env name=VERSION::${VERSION_TAG:9}"
+
+      - name: Build some RPMs
+        uses: ./.github/actions
+        with:
+          version: ${{ env.VERSION }}
+
+      - name: Upload RPMs as Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: telegraf-128tech-${{ env.VERSION }}.x86_64.rpm
+          path: build/telegraf-128tech-*.x86_64.rpm

--- a/128tech.md
+++ b/128tech.md
@@ -2,31 +2,24 @@
 
 This README will describe how to modify and build Telegraf for telegraf-128tech.
 
-## Fetching Dependencies
+## Pulling in Upstream Changes
 
-At some point, all of the Telegraf dependencies will need to be pulled down. This will be done during build automatically unless you've already done so and use the flag to skip that step (see "Building a New RPM"). _It's nice to do this manually because there's poor visibility into the build step_.
+When updating an existing version, the tasks are straight forward.
 
-If you try to run commands without having the dependencies downloaded, you will see errors of the following form.
+1. Merge the upstream branch
+2. Cherry-pick desired changes that exist on some other upstream branch (master for example)
 
-```
-internal/internal.go:24:2: cannot find package "github.com/alecthomas/units" in any of:
-        /usr/local/go/src/github.com/alecthomas/units (from $GOROOT)
-        /go/src/github.com/alecthomas/units (from $GOPATH)
-```
+## Moving to a New Upstream Version
 
-To fetch dependencies directly, you can do it simply from the shell. See "Using the Shell" for how to get into it. From the shell's default directory, simply run:
+When moving to a new upstream version, things are a little more complicated. It requires identification of what has been added to our custom telegraf version which must be pulled into the new release branch. This can be done as described in [this little article](https://til.hashrocket.com/posts/18139f4f20-list-different-commits-between-two-branches).
 
-```
-dep ensure --vendor-only -v
-```
-
-The above command provides the best visibility. The technically sanctioned fetch step is:
+First, pull down the new upstream branch. Then, determine what's been added locally and needs to be included in the new custom build. Do this by finding the commits that were added in the custom branch. This example uses release 1.14, but that will change as time passes.
 
 ```
-make deps
+git log --no-merges --left-right --graph --cherry-pick --oneline release-1.14..release-128tech-1.14
 ```
 
-It does take some time to complete. After that, the dependencies exist in the `vendor` folder and don't need to be fetched again.
+That should provide a limited number of commits that will need to be cherry-picked from the original custom branch to the new one. It is possible these would already exist in the new upstream branch if they were back ported to the custom branch.
 
 ## Building a New RPM
 

--- a/128tech.md
+++ b/128tech.md
@@ -1,0 +1,65 @@
+# Contributions
+
+This README will describe how to modify and build Telegraf for telegraf-128tech.
+
+## Fetching Dependencies
+
+At some point, all of the Telegraf dependencies will need to be pulled down. This will be done during build automatically unless you've already done so and use the flag to skip that step (see "Building a New RPM"). _It's nice to do this manually because there's poor visibility into the build step_.
+
+If you try to run commands without having the dependencies downloaded, you will see errors of the following form.
+
+```
+internal/internal.go:24:2: cannot find package "github.com/alecthomas/units" in any of:
+        /usr/local/go/src/github.com/alecthomas/units (from $GOROOT)
+        /go/src/github.com/alecthomas/units (from $GOPATH)
+```
+
+To fetch dependencies directly, you can do it simply from the shell. See "Using the Shell" for how to get into it. From the shell's default directory, simply run:
+
+```
+dep ensure --vendor-only -v
+```
+
+The above command provides the best visibility. The technically sanctioned fetch step is:
+
+```
+make deps
+```
+
+It does take some time to complete. After that, the dependencies exist in the `vendor` folder and don't need to be fetched again.
+
+## Building a New RPM
+
+Building a new RPM should be straight forward. The necessary building environments exist in the CI docker containers. There is a script `./scripts/docker-env` that wraps docker commands for easy use. To build an RPM from the current source code (example versioning used), simply run:
+
+```
+./scripts/docker-env build --version 1.13.1 --release 2
+```
+
+This will produce new RPMs and place them into the `build` directory.
+
+Fetching can be skipped by using the `--no-fetch` flag:
+
+```
+./scripts/docker-env build --version 1.13.1 --release 3 --no-fetch
+```
+
+## Using the Shell
+
+While not a comprehensive guide, this will get you started. You can drop into the docker environment by running:
+
+```
+./scripts/docker-env shell
+```
+
+From there, you can use `go` and the Telegraf `make` commands as desired. For a few examples, to run all the tests, simply run:
+
+```
+make test
+```
+
+or to run a single plugin's tests, run
+
+```
+go test ./plugins/outputs/http/
+```

--- a/128tech.md
+++ b/128tech.md
@@ -16,7 +16,7 @@ When moving to a new upstream version, things are a little more complicated. It 
 First, pull down the new upstream branch. Then, determine what's been added locally and needs to be included in the new custom build. Do this by finding the commits that were added in the custom branch. This example uses release 1.14, but that will change as time passes.
 
 ```
-git log --no-merges --left-right --graph --cherry-pick --oneline release-1.14..release-128tech-1.14
+git log --no-merges --left-right --graph --cherry-pick --oneline release-1.14..release-128tech-1.14 | tail -r
 ```
 
 That should provide a limited number of commits that will need to be cherry-picked from the original custom branch to the new one. It is possible these would already exist in the new upstream branch if they were back ported to the custom branch.
@@ -30,8 +30,6 @@ Building a new RPM should be straight forward. The necessary building environmen
 ```
 
 This will produce new RPMs and place them into the `build` directory.
-
-Fetching can be skipped by using the `--no-fetch` flag:
 
 ```
 ./scripts/docker-env build --version 1.13.1 --release 3 --no-fetch
@@ -48,11 +46,13 @@ While not a comprehensive guide, this will get you started. You can drop into th
 From there, you can use `go` and the Telegraf `make` commands as desired. For a few examples, to run all the tests, simply run:
 
 ```
-make test
+go get -v -t -d ./...
+go test -short ./...
 ```
 
 or to run a single plugin's tests, run
 
 ```
+go get -v -t -d ./...
 go test ./plugins/outputs/http/
 ```

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -165,6 +165,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/sysstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/system"
 	_ "github.com/influxdata/telegraf/plugins/inputs/systemd_units"
+	_ "github.com/influxdata/telegraf/plugins/inputs/t128_metrics"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tail"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tcp_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/teamspeak"

--- a/plugins/inputs/t128_metrics/README.md
+++ b/plugins/inputs/t128_metrics/README.md
@@ -1,6 +1,6 @@
 # 128T Metrics Input Plugin
 
-The metrics input pluging collects metrics from a 128T instance.
+The metrics input plugin collects metrics from a 128T instance.
 
 ### Configuration
 

--- a/plugins/inputs/t128_metrics/README.md
+++ b/plugins/inputs/t128_metrics/README.md
@@ -1,0 +1,34 @@
+# 128T Metrics Input Plugin
+
+The metrics input pluging collects metrics from a 128T instance.
+
+### Configuration
+
+```toml
+# Read metrics from a 128T instance
+[[inputs.t128_metrics]]
+## Required. The base url for metrics collection
+# base_url = "http://localhost:31517/api/v1/router/Fabric128/"
+
+## A socket to use for retrieving metrics - unused by default
+# unix_socket = "/var/run/128technology/web-server.sock"
+
+## The maximum number of requests to be in flight at once
+# max_simultaneous_requests = 20
+
+## Amount of time allowed to complete a single HTTP request
+# timeout = "5s"
+
+## The metrics to collect
+# [[inputs.t128_metrics.metric]]
+# name = "cpu"
+#
+# [inputs.t128_metrics.metric.fields]
+## Refer to the 128T REST swagger documentation for the list of available metrics
+#     key_name = "stats/<path_to_metric>"
+#     utilization = "stats/cpu/utilization"
+#
+## [inputs.t128_metrics.metric.parameters]
+#     parameter_name = ["value1", "value2"]
+#     core = ["1", "2"]
+```

--- a/plugins/inputs/t128_metrics/api.go
+++ b/plugins/inputs/t128_metrics/api.go
@@ -1,0 +1,50 @@
+package t128_metrics
+
+// RequestMetric describes one element that will need to be retrieved from the back end
+type RequestMetric struct {
+	ID             string
+	Parameters     []RequestParameter
+	OutMeasurement string
+	OutField       string
+}
+
+// RequestParameter is the simple form of a metric's parameters
+type RequestParameter = struct {
+	Name    string   `json:"name"`
+	Values  []string `json:"values,omitempty"`
+	Itemize bool     `json:"itemize"`
+}
+
+// ResponseMetric is a single item in this JSON list
+// [
+//   {
+//     "id": "/stats/active-sources",
+//     "permutations": [
+//       {
+//         "parameters": [
+//           {
+//             "name": "node",
+//             "value": "test1"
+//           }
+//         ],
+//         "value": "0"
+//       }
+//     ]
+//   }
+// ]
+type ResponseMetric struct {
+	ID           string                `json:"id"`
+	Permutations []ResponsePermutation `json:"permutations"`
+}
+
+// ResponsePermutation is a uniquely tagged value within a ResponseMetric
+type ResponsePermutation struct {
+	Parameters []ResponseParameter `json:"parameters"`
+	Value      *string             `json:"value"`
+}
+
+// ResponseParameter describes the format of a parameter produced by the 128T REST API
+type ResponseParameter struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}

--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -200,10 +200,12 @@ func (plugin *T128Metrics) createRequest(baseURL string, metric RequestMetric) (
 		return nil, fmt.Errorf("failed to create request body for metric '%s': %w", metric.ID, err)
 	}
 
-	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewBuffer(body))
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request for metric '%s': %w", metric.ID, err)
 	}
+
+	request.Header.Add("Content-Type", "application/json")
 
 	return request, nil
 }

--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -1,0 +1,269 @@
+package t128_metrics
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/internal"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+// T128Metrics is an input for metrics of a 128T router instance
+type T128Metrics struct {
+	BaseURL                 string             `toml:"base_url"`
+	UnixSocket              string             `toml:"unix_socket"`
+	ConfiguredMetrics       []ConfiguredMetric `toml:"metric"`
+	Timeout                 internal.Duration  `toml:"timeout"`
+	MaxSimultaneousRequests int                `toml:"max_simultaneous_requests"`
+
+	client  *http.Client
+	limiter *requestLimiter
+	metrics []RequestMetric
+}
+
+// ConfiguredMetric represents a single configured metric element
+type ConfiguredMetric struct {
+	Name       string              `toml:"name"`
+	Fields     map[string]string   `toml:"fields"`
+	Parameters map[string][]string `toml:"parameters"`
+}
+
+var sampleConfig = `
+# Read metrics from a 128T instance
+[[inputs.t128_metrics]]
+## Required. The base url for metrics collection
+# base_url = "http://localhost:31517/api/v1/router/Fabric128/"
+
+## A socket to use for retrieving metrics - unused by default
+# unix_socket = "/var/run/128technology/web-server.sock"
+
+## The maximum number of requests to be in flight at once
+# max_simultaneous_requests = 20
+
+## Amount of time allowed to complete a single HTTP request
+# timeout = "5s"
+
+## The metrics to collect
+# [[inputs.t128_metrics.metric]]
+# name = "cpu"
+#
+# [inputs.t128_metrics.metric.fields]
+## Refer to the 128T REST swagger documentation for the list of available metrics
+#     key_name = "stats/<path_to_metric>"
+#     utilization = "stats/cpu/utilization"
+#
+## [inputs.t128_metrics.metric.parameters]
+#     parameter_name = ["value1", "value2"]
+#     core = ["1", "2"]
+`
+
+// SampleConfig returns the default configuration of the Input
+func (*T128Metrics) SampleConfig() string {
+	return sampleConfig
+}
+
+// Description returns a one-sentence description on the Input
+func (*T128Metrics) Description() string {
+	return "Read metrics from a 128T router instance"
+}
+
+// Init sets up the input to be ready for action
+func (plugin *T128Metrics) Init() error {
+	if plugin.BaseURL[len(plugin.BaseURL)-1:] != "/" {
+		plugin.BaseURL += "/"
+	}
+
+	transport := http.DefaultTransport
+
+	if plugin.UnixSocket != "" {
+		transport = &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", plugin.UnixSocket)
+			},
+		}
+	}
+
+	plugin.client = &http.Client{Transport: transport, Timeout: plugin.Timeout.Duration}
+	plugin.limiter = newRequestLimiter(plugin.MaxSimultaneousRequests)
+	plugin.metrics = configuredMetricsToRequestMetrics(plugin.ConfiguredMetrics)
+
+	return nil
+}
+
+// Gather takes in an accumulator and adds the metrics that the Input
+// gathers. This is called every "interval"
+func (plugin *T128Metrics) Gather(acc telegraf.Accumulator) error {
+	timestamp := time.Now().Round(time.Second)
+
+	var wg sync.WaitGroup
+	wg.Add(len(plugin.metrics))
+
+	for _, requestMetric := range plugin.metrics {
+		go func(metric RequestMetric) {
+			plugin.retrieveMetric(metric, acc, timestamp)
+			wg.Done()
+		}(requestMetric)
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func (plugin *T128Metrics) retrieveMetric(metric RequestMetric, acc telegraf.Accumulator, timestamp time.Time) {
+	request, err := plugin.createRequest(plugin.BaseURL, metric)
+	if err != nil {
+		acc.AddError(fmt.Errorf("failed to create a request for metric %s: %w", metric.ID, err))
+		return
+	}
+
+	plugin.limiter.wait()
+	response, err := plugin.client.Do(request)
+	plugin.limiter.done()
+
+	if err != nil {
+		acc.AddError(fmt.Errorf("failed to retrieve metric %s: %w", metric.ID, err))
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		message, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			message = []byte("")
+		}
+
+		acc.AddError(fmt.Errorf("status code %d not OK for metric %s: %s", response.StatusCode, metric.ID, message))
+		return
+	}
+
+	var responseMetrics []ResponseMetric
+	if err := json.NewDecoder(response.Body).Decode(&responseMetrics); err != nil {
+		acc.AddError(fmt.Errorf("failed to decode response for metric %s: %w", metric.ID, err))
+		return
+	}
+
+	for _, responseMetric := range responseMetrics {
+		for _, permutation := range responseMetric.Permutations {
+			if permutation.Value == nil {
+				continue
+			}
+
+			tags := make(map[string]string)
+			for _, parameter := range permutation.Parameters {
+				tags[parameter.Name] = parameter.Value
+			}
+
+			acc.AddFields(
+				metric.OutMeasurement,
+				map[string]interface{}{metric.OutField: tryNumericConversion(*permutation.Value)},
+				tags,
+				timestamp)
+		}
+	}
+}
+
+func (plugin *T128Metrics) createRequest(baseURL string, metric RequestMetric) (*http.Request, error) {
+	content := struct {
+		Parameters []RequestParameter `json:"parameters,omitempty"`
+	}{
+		metric.Parameters,
+	}
+
+	body, err := json.Marshal(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request body for metric '%s': %w", metric.ID, err)
+	}
+
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewBuffer(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for metric '%s': %w", metric.ID, err)
+	}
+
+	return request, nil
+}
+
+func configuredMetricsToRequestMetrics(configuredMetrics []ConfiguredMetric) []RequestMetric {
+	requestMetrics := make([]RequestMetric, 0)
+
+	for _, configMetric := range configuredMetrics {
+		for fieldName, fieldPath := range configMetric.Fields {
+			// Sort names for consistency in testing. It's not free, but only happens during startup.
+			parameterNames := make([]string, 0, len(configMetric.Parameters))
+			for parameterName := range configMetric.Parameters {
+				parameterNames = append(parameterNames, parameterName)
+			}
+			sort.Strings(parameterNames)
+
+			parameters := make([]RequestParameter, 0, len(configMetric.Parameters))
+			for _, parameterName := range parameterNames {
+				values := configMetric.Parameters[parameterName]
+				parameters = append(parameters, RequestParameter{
+					Name:    parameterName,
+					Values:  values,
+					Itemize: true,
+				})
+			}
+
+			requestMetrics = append(requestMetrics, RequestMetric{
+				ID:             fieldPath,
+				Parameters:     parameters,
+				OutMeasurement: configMetric.Name,
+				OutField:       fieldName,
+			})
+		}
+	}
+
+	return requestMetrics
+}
+
+func tryNumericConversion(value string) interface{} {
+	if i, err := strconv.Atoi(value); err == nil {
+		return i
+	} else if f, err := strconv.ParseFloat(value, 64); err == nil {
+		return f
+	} else {
+		return value
+	}
+}
+
+type requestLimiter struct {
+	synchronizer chan struct{}
+}
+
+func newRequestLimiter(limit int) *requestLimiter {
+	limiter := &requestLimiter{make(chan struct{}, limit)}
+
+	for i := 0; i < limit; i++ {
+		limiter.done()
+	}
+
+	return limiter
+}
+
+func (l *requestLimiter) wait() {
+	<-l.synchronizer
+}
+
+func (l *requestLimiter) done() {
+	l.synchronizer <- struct{}{}
+}
+
+func init() {
+	inputs.Add("t128_metrics", func() telegraf.Input {
+		return &T128Metrics{
+			Timeout:                 internal.Duration{Duration: time.Second * 5},
+			MaxSimultaneousRequests: 20,
+		}
+	})
+}

--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -32,6 +32,7 @@ type T128Metrics struct {
 	ConfiguredMetrics       []ConfiguredMetric `toml:"metric"`
 	Timeout                 internal.Duration  `toml:"timeout"`
 	MaxSimultaneousRequests int                `toml:"max_simultaneous_requests"`
+	UseIntegerConversion    bool               `toml:"use_integer_conversion"`
 
 	client  *http.Client
 	limiter *requestLimiter
@@ -56,6 +57,9 @@ var sampleConfig = `
 
 ## The maximum number of requests to be in flight at once
 # max_simultaneous_requests = 20
+
+## Whether to attempt conversion of values to integer before conversion to float
+# use_integer_conversion = false
 
 ## Amount of time allowed to complete a single HTTP request
 # timeout = "5s"
@@ -181,7 +185,10 @@ func (plugin *T128Metrics) retrieveMetric(metric RequestMetric, acc telegraf.Acc
 
 			acc.AddFields(
 				metric.OutMeasurement,
-				map[string]interface{}{metric.OutField: tryNumericConversion(*permutation.Value)},
+				map[string]interface{}{metric.OutField: tryNumericConversion(
+					plugin.UseIntegerConversion,
+					*permutation.Value),
+				},
 				tags,
 				timestamp)
 		}
@@ -244,14 +251,18 @@ func configuredMetricsToRequestMetrics(configuredMetrics []ConfiguredMetric) []R
 	return requestMetrics
 }
 
-func tryNumericConversion(value string) interface{} {
-	if i, err := strconv.Atoi(value); err == nil {
-		return i
-	} else if f, err := strconv.ParseFloat(value, 64); err == nil {
-		return f
-	} else {
-		return value
+func tryNumericConversion(useIntegerConversion bool, value string) interface{} {
+	if useIntegerConversion {
+		if i, err := strconv.Atoi(value); err == nil {
+			return i
+		}
 	}
+
+	if f, err := strconv.ParseFloat(value, 64); err == nil {
+		return f
+	}
+
+	return value
 }
 
 type requestLimiter struct {
@@ -281,6 +292,7 @@ func init() {
 		return &T128Metrics{
 			Timeout:                 internal.Duration{Duration: DefaultRequestTimeout},
 			MaxSimultaneousRequests: DefaultMaxSimultaneousRequests,
+			UseIntegerConversion:    false,
 		}
 	})
 }

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -557,6 +557,9 @@ func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "POST", r.Method)
+
 		endpoint, ok := endpoints[r.URL.Path]
 		if !ok {
 			w.WriteHeader(404)

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -1,0 +1,512 @@
+package t128_metrics_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	plugin "github.com/influxdata/telegraf/plugins/inputs/t128_metrics"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type Endpoint struct {
+	URL             string
+	Code            int
+	ExpectedRequest string
+	Response        string
+}
+
+var ResponseProcessingTestCases = []struct {
+	Name              string
+	ConfiguredMetrics []plugin.ConfiguredMetric
+	Endpoints         []Endpoint
+	ExpectedMetrics   []*testutil.Metric
+	ExpectedErrors    []string
+}{
+	{
+		Name: "empty results produce no metrics",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints:       []Endpoint{{"/stats/test", 200, "{}", "[]"}},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  nil,
+	},
+	{
+		Name: "none value produces no metric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": null
+			}]
+		}]`}},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  nil,
+	},
+	{
+		Name: "forms string value if it is non numeric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "test-string"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": "test-string"},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "forms int value if it is numeric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "forms float value if it is numeric",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50.5"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50.5},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "adds permutation parameters to metrics",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [
+					{
+						"name": "node",
+						"value": "node1"
+					},
+					{
+						"name": "interface",
+						"value": "intf1"
+					}
+				],
+				"value": "0"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node1", "interface": "intf1"},
+				Fields:      map[string]interface{}{"test-field": 0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "produces multiple metrics for multiple permutations",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test",
+			"permutations": [
+				{
+					"parameters": [
+						{
+							"name": "node",
+							"value": "node1"
+						}
+					],
+					"value": "897"
+				},
+				{
+					"parameters": [
+						{
+							"name": "node",
+							"value": "node2"
+						}
+					],
+					"value": "306"
+				}
+			]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node1"},
+				Fields:      map[string]interface{}{"test-field": 897},
+			},
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node2"},
+				Fields:      map[string]interface{}{"test-field": 306},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "hits multiple endpoints",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}, {
+			"another-test-metric",
+			map[string]string{"another-test-field": "stats/another/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50"
+			}]
+		}]`}, {
+			"/stats/another/test", 200, "{}", `[{
+			"id": "/stats/another/test",
+			"permutations": [{
+				"parameters": [],
+				"value": "60"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+			{
+				Measurement: "another-test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"another-test-field": 60},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name: "propogates errors to accumulator",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"404",
+			map[string]string{"field": "stats/404"},
+			map[string][]string{},
+		}, {
+			"300",
+			map[string]string{"field": "stats/300"},
+			map[string][]string{},
+		}, {
+			"invalid-json",
+			map[string]string{"field": "stats/invalid-json"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{
+			{"/stats/404", 404, "{}", `it's not right`},
+			{"/stats/300", 300, "{}", `it's not right`},
+			{"/stats/invalid-json", 200, "{}", `{"test": }`},
+		},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"status code 404 not OK for metric stats/404: it's not right",
+			"status code 300 not OK for metric stats/300: it's not right",
+			"failed to decode response for metric stats/invalid-json: invalid character '}' looking for beginning of value",
+		},
+	},
+	{
+		Name: "mixes errors and valid results",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"404",
+			map[string]string{"field": "stats/404"},
+			map[string][]string{},
+		}, {
+			"test-metric",
+			map[string]string{"field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{
+			{"/stats/404", 404, "{}", `it's not right`},
+			{"/stats/test", 200, "{}", `[{
+				"id": "/stats/test-metric",
+				"permutations": [{
+					"parameters": [],
+					"value": "50"
+				}]
+			}]`},
+		},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"field": 50},
+			},
+		},
+		ExpectedErrors: []string{
+			"status code 404 not OK for metric stats/404: it's not right",
+		},
+	},
+}
+
+var RequestFormationTestCases = []struct {
+	Name              string
+	ConfiguredMetrics []plugin.ConfiguredMetric
+	Endpoints         []Endpoint
+}{
+	{
+		Name: "empty request body with no parameters",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", "[]"}},
+	},
+	{
+		Name: "itemizes with no filter values for empty list",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{"interface": {}},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, `{"parameters": [{"name": "interface", "itemize": true}]}`, "[]"}},
+	},
+	{
+		Name: "includes parameter filter values",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{"interface": {"intf1", "intf2"}},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, `{
+				"parameters": [
+					{"name": "interface", "values": ["intf1", "intf2"], "itemize": true}
+				]
+			}`,
+			"[]"}},
+	},
+	{
+		Name: "includes multiple parameter filters",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{
+				"interface": {"intf1", "intf2"},
+				"node":      {"node1", "node2"},
+				"other":     {}},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, `{
+				"parameters": [
+					{"name": "interface", "values": ["intf1", "intf2"], "itemize": true},
+					{"name": "node", "values": ["node1", "node2"], "itemize": true},
+					{"name": "other", "itemize": true}
+				]
+			}`,
+			"[]"}},
+	},
+}
+
+func TestT128MetricsResponseProcessing(t *testing.T) {
+	for _, testCase := range ResponseProcessingTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			fakeServer := createTestServer(t, testCase.Endpoints)
+			defer fakeServer.Close()
+
+			plugin := &plugin.T128Metrics{
+				BaseURL:                 fakeServer.URL,
+				MaxSimultaneousRequests: 20,
+				ConfiguredMetrics:       testCase.ConfiguredMetrics,
+			}
+
+			var acc testutil.Accumulator
+			plugin.Init()
+
+			plugin.Gather(&acc)
+
+			var errorStrings []string = nil
+			for _, err := range acc.Errors {
+				errorStrings = append(errorStrings, err.Error())
+			}
+
+			require.ElementsMatch(t, testCase.ExpectedErrors, errorStrings)
+
+			// Timestamps aren't important, but need to match
+			for _, m := range acc.Metrics {
+				m.Time = time.Time{}
+			}
+
+			// Avoid specifying this unused type for each field
+			for _, m := range testCase.ExpectedMetrics {
+				m.Type = telegraf.Untyped
+			}
+
+			require.ElementsMatch(t, testCase.ExpectedMetrics, acc.Metrics)
+		})
+	}
+}
+
+func TestT128MetricsRequestFormation(t *testing.T) {
+	for _, testCase := range RequestFormationTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			fakeServer := createTestServer(t, testCase.Endpoints)
+			defer fakeServer.Close()
+
+			plugin := &plugin.T128Metrics{
+				BaseURL:                 fakeServer.URL,
+				MaxSimultaneousRequests: 20,
+				ConfiguredMetrics:       testCase.ConfiguredMetrics,
+			}
+
+			var acc testutil.Accumulator
+			plugin.Init()
+
+			require.NoError(t, acc.GatherError(plugin.Gather))
+		})
+	}
+}
+
+func TestT128MetricsErrorResponses(t *testing.T) {
+	for _, testCase := range RequestFormationTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			fakeServer := createTestServer(t, testCase.Endpoints)
+			defer fakeServer.Close()
+
+			plugin := &plugin.T128Metrics{
+				BaseURL:                 fakeServer.URL,
+				MaxSimultaneousRequests: 20,
+				ConfiguredMetrics:       testCase.ConfiguredMetrics,
+			}
+
+			var acc testutil.Accumulator
+			plugin.Init()
+
+			require.NoError(t, acc.GatherError(plugin.Gather))
+		})
+	}
+}
+
+func TestT128MetricsRequestLimiting(t *testing.T) {
+	inFlight := int32(0)
+	const limit = 3
+	const metricCount = 20
+
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		currentInFlight := atomic.AddInt32(&inFlight, 1)
+		defer atomic.AddInt32(&inFlight, -1)
+
+		fmt.Println(currentInFlight)
+		require.LessOrEqual(t, currentInFlight, int32(limit))
+
+		time.Sleep(time.Duration(rand.Intn(20)) * time.Millisecond)
+		w.Write([]byte("[]"))
+	}))
+
+	configuredMetrics := make([]plugin.ConfiguredMetric, 0, metricCount)
+	for i := 0; i < metricCount; i++ {
+		configuredMetrics = append(configuredMetrics, plugin.ConfiguredMetric{
+			fmt.Sprintf("test-metric-%d", i),
+			map[string]string{"test-field": fmt.Sprintf("stats/test/%d", i)},
+			map[string][]string{},
+		})
+	}
+
+	plugin := &plugin.T128Metrics{
+		BaseURL:                 fakeServer.URL,
+		MaxSimultaneousRequests: limit,
+		ConfiguredMetrics:       configuredMetrics,
+	}
+
+	var acc testutil.Accumulator
+	plugin.Init()
+
+	require.NoError(t, acc.GatherError(plugin.Gather))
+}
+
+func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
+	endpoints := make(map[string]Endpoint)
+	for _, endpoint := range e {
+		endpoints[endpoint.URL] = endpoint
+	}
+
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		endpoint, ok := endpoints[r.URL.Path]
+		if !ok {
+			w.WriteHeader(404)
+			return
+		}
+
+		if endpoint.ExpectedRequest != "" {
+			contents, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(500)
+				return
+			}
+
+			require.JSONEq(t, endpoint.ExpectedRequest, string(contents), "Unexpected request body for endpoint %s", endpoint.URL)
+		}
+
+		w.WriteHeader(endpoint.Code)
+		w.Write([]byte(endpoint.Response))
+	}))
+
+	return fakeServer
+}

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -532,7 +532,7 @@ func TestTimoutUsedForRequests(t *testing.T) {
 	require.EqualError(
 		t,
 		acc.Errors[0],
-		fmt.Sprintf("failed to retrieve metric stats/test: Post %s/stats/test: net/http: request canceled (Client.Timeout exceeded while awaiting headers)", fakeServer.URL))
+		fmt.Sprintf("failed to retrieve metric stats/test: Post \"%s/stats/test\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)", fakeServer.URL))
 
 	fakeServer.Close()
 }

--- a/plugins/outputs/http/README.md
+++ b/plugins/outputs/http/README.md
@@ -11,6 +11,9 @@ data formats.  For data_formats that support batching, metrics are sent in batch
   ## URL is the address to send metrics to
   url = "http://127.0.0.1:8080/telegraf"
 
+  ## Unix Socket is a unix socket serving HTTP to send metrics to
+  # unix_socket = "/var/run/http_server.sock"
+
   ## Timeout for HTTP message
   # timeout = "5s"
 

--- a/plugins/outputs/http/http_unix_test.go
+++ b/plugins/outputs/http/http_unix_test.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/serializers/influx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnixStatusCode(t *testing.T) {
+	ts := httptest.NewUnstartedServer(http.NotFoundHandler())
+	defer ts.Close()
+
+	socket := "./test.sock"
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatalf("Failed to create unix socket: %s", socket)
+	}
+
+	ts.Listener = listener
+	ts.Start()
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", ts.Listener.Addr().String()))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		plugin     *HTTP
+		statusCode int
+		errFunc    func(t *testing.T, err error)
+	}{
+		{
+			name: "success",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusOK,
+			errFunc: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "1xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: 103,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "3xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusMultipleChoices,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "4xx status is an error",
+			plugin: &HTTP{
+				URL:        u.String(),
+				UnixSocket: socket,
+			},
+			statusCode: http.StatusMultipleChoices,
+			errFunc: func(t *testing.T, err error) {
+				require.Error(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			})
+
+			serializer := influx.NewSerializer()
+			tt.plugin.SetSerializer(serializer)
+			err = tt.plugin.Connect()
+			require.NoError(t, err)
+
+			err = tt.plugin.Write([]telegraf.Metric{getMetric()})
+			tt.errFunc(t, err)
+		})
+	}
+}

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import subprocess
+import os
+import sys
+
+ROOT = pathlib.Path(__file__).parent.parent.resolve()
+SCRIPTS = ROOT / "scripts"
+IMAGE_NAME = "telegraf-build"
+
+
+def main():
+    args = parse_args()
+    create_docker_env(args.docker_file)
+
+    if args.which == "build":
+        build(args)
+    else:
+        shell(args)
+
+
+def build(args):
+    cmd = [] if args.no_fetch else ["make", "deps", "&&"]
+
+    cmd.extend(
+        [
+            f"./scripts/build.py",
+            "--package",
+            "--platform=linux",
+            "--arch=amd64",
+            f"--name={args.name}",
+            f"--version={args.version}",
+            f"--iteration={args.release}",
+            "--release",
+            "--no-get",
+        ]
+    )
+
+    try:
+        cmd = build_docker_command(args.docker_file, ["bash", "-c", " ".join(cmd)])
+
+        subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as error:
+        print("Failed to build the RPM")
+        sys.exit(1)
+
+
+def shell(args):
+    subprocess.run(build_docker_command(args.docker_file, ["bash"], interactive=True))
+
+
+def create_docker_env(docker_file):
+    try:
+        subprocess.check_call(
+            ["docker", "build", "-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
+        )
+    except subprocess.CalledProcessError as error:
+        print("Failed to build the docker image")
+        sys.exit(1)
+
+
+def build_docker_command(docker_file, internal_cmd, interactive=False):
+    cmd = [
+        "docker",
+        "run",
+    ]
+
+    if internal_cmd:
+        cmd.append("-it")
+
+    cmd.extend(
+        [
+            "--rm",
+            "-v",
+            f"{ROOT}:/go/src/github.com/influxdata/telegraf",
+            "-w",
+            "/go/src/github.com/influxdata/telegraf",
+            IMAGE_NAME,
+        ]
+    )
+
+    cmd.extend(internal_cmd)
+    print(" ".join(cmd))
+
+    return cmd
+
+
+def parse_args():
+    arg_parser = argparse.ArgumentParser(
+        description="A docker based environment for building telegraf RPMS",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    subcommands = arg_parser.add_subparsers()
+
+    build_parser = subcommands.add_parser(
+        "build", help="Build an RPM from within the docker environment"
+    )
+
+    shell = subcommands.add_parser(
+        "shell", help="Drop into a shell in the docker environment"
+    )
+
+    ## Build args
+    build_parser.set_defaults(which="build")
+
+    build_parser.add_argument(
+        "--version", help="The version the produced RPM should have", required=True
+    )
+
+    build_parser.add_argument(
+        "--release", help="The release version to use for the RPM", default=1
+    )
+
+    build_parser.add_argument(
+        "--name", help="The name the RPM should have", default="telegraf-128tech"
+    )
+
+    build_parser.add_argument(
+        "--no-fetch",
+        help="Whether to fetch dependencies before building. If not, you should have run `make deps` in your source directory.",
+        action="store_true",
+    )
+
+    ## Shell args
+    shell.set_defaults(which="shell")
+
+    ## Common args
+    arg_parser.add_argument(
+        "--docker-file",
+        help="The docker file to use for the container",
+        default=(SCRIPTS / "ci-1.13.docker"),
+    )
+
+    args = arg_parser.parse_args()
+
+    args.docker_file = str(args.docker_file)
+
+    if not pathlib.Path(args.docker_file).exists():
+        print(f'docker file "{args.docker_file}" does not exist')
+        sys.exit(1)
+
+    return args
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -131,7 +131,7 @@ def parse_args():
     arg_parser.add_argument(
         "--docker-file",
         help="The docker file to use for the container",
-        default=(SCRIPTS / "ci-1.13.docker"),
+        default=(SCRIPTS / "ci-1.15.docker"),
     )
 
     args = arg_parser.parse_args()


### PR DESCRIPTION
### Included 1.14 Commits

Everything applied cleanly. The few excluded commits were ones that had been cherry-picked from 1.15 into 1.14, so the relevant code is already in 1.16. Beyond that, those commits caused conflicts.

```
> 82243de Unix sockets for http output plugin
> 8ac5c2d Create a docker-env script to simplify the building of telegraf-128tech RPMs
> c65c9f8 add support for SIGUSR1 to trigger flush (#7366)                                  <excluded>
> 65ccba9 Support Go execd plugins with shim (#7283)                                        <excluded>
> 5708f3f shim improvements for docs, clean quit, and slow readers (#7452)                  <excluded>
> 58b77d1 fix issue with execd-multiline influx line protocol (#7463)                       <excluded>
> ea7f82a fix issue with stream parser blocking when data is in buffer (#7631)              <excluded>
> aec56f1 Add some more useful information about maintaining the 128tech branching model
> e09368b Create the t128_metrics input plugin
> 28b4bea Address review comments
> 27dc1fa Add CI to 128tech telegraf fork
> 03adbbb Add a release workflow for simpler RPM building on release
> 0fa78dc Convert t128_metrics timeout to internal.Duration to be correctly parsed
> 23ecf7f Update t128_metrics_test
> ea72430 Add a script that more intelligently parses the version tag
> 2a78c84 Reference patch input in action.yaml
> ad4d91c Include content-type in t128_metrics HTTP requests
> 91c623c Update t128_metrics integer conversion to be optional
```

### Additional Changes

I also made some minimal changes to the 128 specific docs and CI for compatibility with the latest telegraf code.
