### PR TITLE
Make Influx serializer timestamp units configurable

### DIFF
--- a/.github/actions/Dockerfile
+++ b/.github/actions/Dockerfile
@@ -1,1 +1,1 @@
-../../scripts/ci-1.13.docker
+../../scripts/ci-1.15.docker

--- a/.github/actions/action.yaml
+++ b/.github/actions/action.yaml
@@ -10,12 +10,11 @@ inputs:
 runs:
   using: "docker"
   image: "Dockerfile"
+  env:
+    NAME: telegraf-128tech
+    version: ${{ inputs.version }}
+    rpm_iteration: ${{ inputs.patch }}
+    rpm_version: ${{ inputs.version }}-${{ inputs.patch }}
   args:
-    - ./scripts/build.py
-    - --package
-    - --platform=linux
-    - --arch=amd64
-    - --name=telegraf-128tech
-    - --version=${{ inputs.version }}
-    - --iteration=${{ inputs.patch }}
-    - --release
+    - make
+    - telegraf-128tech-${{ inputs.version }}-${{ inputs.patch }}.x86_64.rpm

--- a/.github/scripts/set_version_environment_variables.sh
+++ b/.github/scripts/set_version_environment_variables.sh
@@ -8,10 +8,10 @@ if [ -z $BASH_REMATCH ]; then
     exit 1
 fi
 
-echo "::set-env name=VERSION::${BASH_REMATCH[1]}"
+echo "VERSION=${BASH_REMATCH[1]}" >> $GITHUB_ENV
 
 if [ ! -z ${BASH_REMATCH[3]} ]; then
-    echo "::set-env name=VERSION_PATCH::${BASH_REMATCH[3]}"
+    echo "VERSION_PATCH=${BASH_REMATCH[3]}" >> $GITHUB_ENV
 else
-    echo "::set-env name=VERSION_PATCH::1"
+    echo "VERSION_PATCH=1" >> $GITHUB_ENV
 fi

--- a/.github/scripts/set_version_environment_variables.sh
+++ b/.github/scripts/set_version_environment_variables.sh
@@ -8,10 +8,14 @@ if [ -z $BASH_REMATCH ]; then
     exit 1
 fi
 
-echo "VERSION=${BASH_REMATCH[1]}" >> $GITHUB_ENV
+VERSION=${BASH_REMATCH[1]}
 
 if [ ! -z ${BASH_REMATCH[3]} ]; then
-    echo "VERSION_PATCH=${BASH_REMATCH[3]}" >> $GITHUB_ENV
+    VERSION_PATCH=${BASH_REMATCH[3]}
 else
-    echo "VERSION_PATCH=1" >> $GITHUB_ENV
+    VERSION_PATCH=1
 fi
+
+echo "VERSION=${VERSION}" >> $GITHUB_ENV
+echo "VERSION_PATCH=${VERSION_PATCH}" >> $GITHUB_ENV
+echo "RPM_NAME=telegraf-128tech-${VERSION}-${VERSION_PATCH}.x86_64.rpm" >> $GITHUB_ENV

--- a/.github/workflows/release-128tech.yaml
+++ b/.github/workflows/release-128tech.yaml
@@ -37,6 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: build/${{ env.RPM_NAME }}
+          asset_path: build/dist/${{ env.RPM_NAME }}
           asset_name: ${{ env.RPM_NAME }}
           asset_content_type: application/x-rpm

--- a/.github/workflows/release-128tech.yaml
+++ b/.github/workflows/release-128tech.yaml
@@ -19,13 +19,24 @@ jobs:
         run: bash .github/scripts/set_version_environment_variables.sh
 
       - name: Build some RPMs
+        id: build
         uses: ./.github/actions
         with:
           version: ${{ env.VERSION }}
           patch: ${{ env.VERSION_PATCH }}
 
-      - name: Upload RPMs as Artifacts
-        uses: actions/upload-artifact@v2
+      - name: Get Release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload RPM to Github
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          name: telegraf-128tech-${{ env.VERSION }}.x86_64.rpm
-          path: build/telegraf-128tech-*.x86_64.rpm
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: build/${{ env.RPM_NAME }}
+          asset_name: ${{ env.RPM_NAME }}
+          asset_content_type: application/x-rpm

--- a/Makefile
+++ b/Makefile
@@ -5,37 +5,38 @@ commit := $(shell git rev-parse --short=8 HEAD)
 glibc_version := 2.17
 
 ifdef NIGHTLY
-	version := $(next_version)
-	rpm_version := nightly
-	rpm_iteration := 0
-	deb_version := nightly
-	deb_iteration := 0
-	tar_version := nightly
+	version ?= $(next_version)
+	rpm_version ?= nightly
+	rpm_iteration ?= 0
+	deb_version ?= nightly
+	deb_iteration ?= 0
+	tar_version ?= nightly
 else ifeq ($(tag),)
-	version := $(next_version)
-	rpm_version := $(version)~$(commit)-0
-	rpm_iteration := 0
-	deb_version := $(version)~$(commit)-0
-	deb_iteration := 0
-	tar_version := $(version)~$(commit)
+	version ?= $(next_version)
+	rpm_version ?= $(version)~$(commit)-0
+	rpm_iteration ?= 0
+	deb_version ?= $(version)~$(commit)-0
+	deb_iteration ?= 0
+	tar_version ?= $(version)~$(commit)
 else ifneq ($(findstring -rc,$(tag)),)
-	version := $(word 1,$(subst -, ,$(tag)))
-	version := $(version:v%=%)
+	version_tag := $(word 1,$(subst -, ,$(tag)))
+	version ?= $(version_tag:v%=%)
 	rc := $(word 2,$(subst -, ,$(tag)))
-	rpm_version := $(version)-0.$(rc)
-	rpm_iteration := 0.$(subst rc,,$(rc))
-	deb_version := $(version)~$(rc)-1
-	deb_iteration := 0
-	tar_version := $(version)~$(rc)
+	rpm_version ?= $(version)-0.$(rc)
+	rpm_iteration ?= 0.$(subst rc,,$(rc))
+	deb_version ?= $(version)~$(rc)-1
+	deb_iteration ?= 0
+	tar_version ?= $(version)~$(rc)
 else
-	version := $(tag:v%=%)
-	rpm_version := $(version)-1
-	rpm_iteration := 1
-	deb_version := $(version)-1
-	deb_iteration := 1
-	tar_version := $(version)
+	version ?= $(tag:v%=%)
+	rpm_version ?= $(version)-1
+	rpm_iteration ?= 1
+	deb_version ?= $(version)-1
+	deb_iteration ?= 1
+	tar_version ?= $(version)
 endif
 
+NAME ?= telegraf
 MAKEFLAGS += --no-print-directory
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
@@ -204,37 +205,37 @@ $(buildbin):
 	@mkdir -pv $(dir $@)
 	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
 
-debs := telegraf_$(deb_version)_amd64.deb
-debs += telegraf_$(deb_version)_arm64.deb
-debs += telegraf_$(deb_version)_armel.deb
-debs += telegraf_$(deb_version)_armhf.deb
-debs += telegraf_$(deb_version)_i386.deb
-debs += telegraf_$(deb_version)_mips.deb
-debs += telegraf_$(deb_version)_mipsel.deb
-debs += telegraf_$(deb_version)_s390x.deb
+debs := $(NAME)_$(deb_version)_amd64.deb
+debs += $(NAME)_$(deb_version)_arm64.deb
+debs += $(NAME)_$(deb_version)_armel.deb
+debs += $(NAME)_$(deb_version)_armhf.deb
+debs += $(NAME)_$(deb_version)_i386.deb
+debs += $(NAME)_$(deb_version)_mips.deb
+debs += $(NAME)_$(deb_version)_mipsel.deb
+debs += $(NAME)_$(deb_version)_s390x.deb
 
-rpms += telegraf-$(rpm_version).aarch64.rpm
-rpms += telegraf-$(rpm_version).armel.rpm
-rpms += telegraf-$(rpm_version).armv6hl.rpm
-rpms += telegraf-$(rpm_version).i386.rpm
-rpms += telegraf-$(rpm_version).s390x.rpm
-rpms += telegraf-$(rpm_version).x86_64.rpm
+rpms += $(NAME)-$(rpm_version).aarch64.rpm
+rpms += $(NAME)-$(rpm_version).armel.rpm
+rpms += $(NAME)-$(rpm_version).armv6hl.rpm
+rpms += $(NAME)-$(rpm_version).i386.rpm
+rpms += $(NAME)-$(rpm_version).s390x.rpm
+rpms += $(NAME)-$(rpm_version).x86_64.rpm
 
-tars += telegraf-$(tar_version)_darwin_amd64.tar.gz
-tars += telegraf-$(tar_version)_freebsd_amd64.tar.gz
-tars += telegraf-$(tar_version)_freebsd_i386.tar.gz
-tars += telegraf-$(tar_version)_linux_amd64.tar.gz
-tars += telegraf-$(tar_version)_linux_arm64.tar.gz
-tars += telegraf-$(tar_version)_linux_armel.tar.gz
-tars += telegraf-$(tar_version)_linux_armhf.tar.gz
-tars += telegraf-$(tar_version)_linux_i386.tar.gz
-tars += telegraf-$(tar_version)_linux_mips.tar.gz
-tars += telegraf-$(tar_version)_linux_mipsel.tar.gz
-tars += telegraf-$(tar_version)_linux_s390x.tar.gz
-tars += telegraf-$(tar_version)_static_linux_amd64.tar.gz
+tars += $(NAME)-$(tar_version)_darwin_amd64.tar.gz
+tars += $(NAME)-$(tar_version)_freebsd_amd64.tar.gz
+tars += $(NAME)-$(tar_version)_freebsd_i386.tar.gz
+tars += $(NAME)-$(tar_version)_linux_amd64.tar.gz
+tars += $(NAME)-$(tar_version)_linux_arm64.tar.gz
+tars += $(NAME)-$(tar_version)_linux_armel.tar.gz
+tars += $(NAME)-$(tar_version)_linux_armhf.tar.gz
+tars += $(NAME)-$(tar_version)_linux_i386.tar.gz
+tars += $(NAME)-$(tar_version)_linux_mips.tar.gz
+tars += $(NAME)-$(tar_version)_linux_mipsel.tar.gz
+tars += $(NAME)-$(tar_version)_linux_s390x.tar.gz
+tars += $(NAME)-$(tar_version)_static_linux_amd64.tar.gz
 
-zips += telegraf-$(tar_version)_windows_amd64.zip
-zips += telegraf-$(tar_version)_windows_i386.zip
+zips += $(NAME)-$(tar_version)_windows_amd64.zip
+zips += $(NAME)-$(tar_version)_windows_i386.zip
 
 dists := $(debs) $(rpms) $(tars) $(zips)
 
@@ -271,7 +272,7 @@ $(rpms):
 		--depends coreutils \
 		--depends shadow-utils \
 		--rpm-posttrans scripts/rpm/post-install.sh \
-		--name telegraf \
+		--name $(NAME) \
 		--version $(version) \
 		--iteration $(rpm_iteration) \
         --chdir $(DESTDIR) \
@@ -307,7 +308,7 @@ $(debs):
 		--after-remove scripts/deb/post-remove.sh \
 		--before-remove scripts/deb/pre-remove.sh \
 		--description "Plugin-driven server agent for reporting metrics into InfluxDB." \
-		--name telegraf \
+		--name $(NAME) \
 		--version $(version) \
 		--iteration $(deb_iteration) \
 		--chdir $(DESTDIR) \

--- a/plugins/serializers/influx/README.md
+++ b/plugins/serializers/influx/README.md
@@ -30,6 +30,15 @@ for interoperability.
   ## integer values.  Enabling this option will result in field type errors if
   ## existing data has been written.
   influx_uint_support = false
+
+  ## By default, the line format timestamp is at nanosecond precision. The
+  ## precision can be adjusted here. This parameter can be used to set the
+  ## timestamp units to nanoseconds (`ns`), microseconds (`us` or `µs`),
+  ## milliseconds (`ms`), or seconds (`s`). Note that this parameter will be
+  ## truncated to the nearest power of 10, so if the `influx_timestamp_units`
+  ## are set to `15ms` the timestamps for the serialized line will be output in
+  ## hundredths of a second (`10ms`).
+  influx_timestamp_units = "1ns"
 ```
 
 ### Metrics

--- a/plugins/serializers/influx/influx.go
+++ b/plugins/serializers/influx/influx.go
@@ -97,10 +97,9 @@ func (s *Serializer) SetFieldTypeSupport(typeSupport FieldTypeSupport) {
 
 func (s *Serializer) SetTimestampUnits(units time.Duration) {
 	unitsNanoseconds := units.Nanoseconds()
-	fmt.Printf("Nanoseconds: %v\n", unitsNanoseconds)
 
 	// if the units passed in were less than or equal to zero,
-	// then serialize the timestamp in seconds (the default)
+	// then serialize the timestamp in nanoseconds (the default)
 	if unitsNanoseconds <= 0 {
 		unitsNanoseconds = 1
 	}

--- a/plugins/serializers/influx/influx_test.go
+++ b/plugins/serializers/influx/influx_test.go
@@ -18,12 +18,13 @@ func MustMetric(v telegraf.Metric, err error) telegraf.Metric {
 }
 
 var tests = []struct {
-	name        string
-	maxBytes    int
-	typeSupport FieldTypeSupport
-	input       telegraf.Metric
-	output      []byte
-	errReason   string
+	name           string
+	maxBytes       int
+	typeSupport    FieldTypeSupport
+	input          telegraf.Metric
+	output         []byte
+	errReason      string
+	timestampUnits time.Duration
 }{
 	{
 		name: "minimal",
@@ -230,7 +231,7 @@ var tests = []struct {
 		output: []byte("cpu value=\"howdy\" 0\n"),
 	},
 	{
-		name: "timestamp",
+		name: "default timestamp",
 		input: MustMetric(
 			metric.New(
 				"cpu",
@@ -242,6 +243,21 @@ var tests = []struct {
 			),
 		),
 		output: []byte("cpu value=42 1519194109000000042\n"),
+	},
+	{
+		name: "timestamp second units",
+		input: MustMetric(
+			metric.New(
+				"cpu",
+				map[string]string{},
+				map[string]interface{}{
+					"value": 42.0,
+				},
+				time.Unix(1519194109, 42),
+			),
+		),
+		timestampUnits: time.Second,
+		output:         []byte("cpu value=42 1519194109\n"),
 	},
 	{
 		name:     "split fields exact",
@@ -539,6 +555,7 @@ func TestSerializer(t *testing.T) {
 			serializer.SetMaxLineBytes(tt.maxBytes)
 			serializer.SetFieldSortOrder(SortFields)
 			serializer.SetFieldTypeSupport(tt.typeSupport)
+			serializer.SetTimestampUnits(tt.timestampUnits)
 			output, err := serializer.Serialize(tt.input)
 			if tt.errReason != "" {
 				require.Error(t, err)
@@ -555,6 +572,7 @@ func BenchmarkSerializer(b *testing.B) {
 			serializer := NewSerializer()
 			serializer.SetMaxLineBytes(tt.maxBytes)
 			serializer.SetFieldTypeSupport(tt.typeSupport)
+			serializer.SetTimestampUnits(tt.timestampUnits)
 			for n := 0; n < b.N; n++ {
 				output, err := serializer.Serialize(tt.input)
 				_ = err

--- a/plugins/serializers/registry.go
+++ b/plugins/serializers/registry.go
@@ -67,6 +67,9 @@ type Config struct {
 	// Support unsigned integer output; influx format only
 	InfluxUintSupport bool `toml:"influx_uint_support"`
 
+	// Timestamp units to use for Influx formatted output
+	InfluxTimestampUnits time.Duration `toml:"influx_timestamp_units"`
+
 	// Prefix to add to all measurements, only supports Graphite
 	Prefix string `toml:"prefix"`
 
@@ -190,6 +193,7 @@ func NewInfluxSerializerConfig(config *Config) (Serializer, error) {
 	s.SetMaxLineBytes(config.InfluxMaxLineBytes)
 	s.SetFieldSortOrder(sort)
 	s.SetFieldTypeSupport(typeSupport)
+	s.SetTimestampUnits(config.InfluxTimestampUnits)
 	return s, nil
 }
 

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -22,28 +22,22 @@ def main():
 
 
 def build(args):
-    cmd = [] if args.no_fetch else ["make", "deps", "&&"]
-
-    cmd.extend(
-        [
-            f"./scripts/build.py",
-            "--package",
-            "--platform=linux",
-            "--arch=amd64",
-            f"--name={args.name}",
-            f"--version={args.version}",
-            f"--iteration={args.release}",
-            "--release",
-            "--no-get",
-        ]
-    )
+    env = {
+        **os.environ,
+        "NAME": "telegraf-128tech",
+        "version": args.version,
+        "rpm_iteration": args.release,
+        "rpm_version": f"{args.version}-{args.release}"
+    }
 
     try:
-        cmd = build_docker_command(args.docker_file, ["bash", "-c", " ".join(cmd)])
-
-        subprocess.check_call(cmd)
+        subprocess.run(
+            ["make", f"telegraf-128tech-{args.version}-{args.release}.x86_64.rpm"],
+            env=env,
+            check=True
+        )
     except subprocess.CalledProcessError as error:
-        print("Failed to build the RPM")
+        print("Failed to build the RPM: {error}")
         sys.exit(1)
 
 


### PR DESCRIPTION
### Description

The Influx serializer always produces timestamps in nanoseconds. However, there are consumers which would benefit from second precision. In particular, the Influx API accepts writes with lines in second precision. When telegraf's lines are mixed with those of other sources where the others are producing second precision, it causes issues.

This change allows the serializer to be configured with units for the timestamp. It is the Influx serializer equivalent of the JSON serializer change made in [this PR](https://github.com/influxdata/telegraf/pull/2587).

In configuration, this option would look like this:
```
[[outputs.file]]
  files = ["stdout"]
  data_format = "influx"
  influx_timestamp_units = "1s"
```