### PR TITLE
Allow the t128_metrics input to retrieve metrics in bulk

### DIFF
--- a/plugins/inputs/t128_metrics/README.md
+++ b/plugins/inputs/t128_metrics/README.md
@@ -13,6 +13,10 @@ The metrics input plugin collects metrics from a 128T instance.
 ## A socket to use for retrieving metrics - unused by default
 # unix_socket = "/var/run/128technology/web-server.sock"
 
+## Whether or not to use the bulk retrieval API. If used, the base_url should
+## point directly to the bulk metrics endpoint.
+# use_bulk_retrieval = false
+
 ## The maximum number of requests to be in flight at once
 # max_simultaneous_requests = 20
 

--- a/plugins/inputs/t128_metrics/api.go
+++ b/plugins/inputs/t128_metrics/api.go
@@ -8,6 +8,15 @@ type RequestMetric struct {
 	OutField       string
 }
 
+// BulkRequestMetrics describes a set of elements to be retrieved from the back end
+type BulkRequestMetrics struct {
+	IDs            []string           `json:"ids"`
+	Parameters     []RequestParameter `json:"parameters,omitempty"`
+	OutMeasurement string             `json:"-"`
+	OutFields      map[string]string  `json:"-"`
+	RequestBody    []byte             `json:"-"`
+}
+
 // RequestParameter is the simple form of a metric's parameters
 type RequestParameter = struct {
 	Name    string   `json:"name"`

--- a/plugins/inputs/t128_metrics/retriever.go
+++ b/plugins/inputs/t128_metrics/retriever.go
@@ -1,0 +1,232 @@
+package t128_metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/influxdata/telegraf"
+)
+
+// Retriever implements a way to retrieve metrics
+type Retriever interface {
+	RequestCount() int
+	Describe(index int) string
+	CreateRequest(index int, baseURL string) (*http.Request, error)
+	PopulateResponse(index int, acc telegraf.Accumulator, responseMetrics []ResponseMetric, timestamp time.Time)
+}
+
+// NewIndividualRetriever produces an individual retriever
+func NewIndividualRetriever(useIntegerConversion bool, configuredMetrics []ConfiguredMetric) Retriever {
+	requestMetrics := make([]RequestMetric, 0)
+
+	for _, configMetric := range configuredMetrics {
+		parameters := toRequestParameters(configMetric.Parameters)
+
+		for fieldName, fieldPath := range configMetric.Fields {
+			requestMetrics = append(requestMetrics, RequestMetric{
+				ID:             fieldPath,
+				Parameters:     parameters,
+				OutMeasurement: configMetric.Name,
+				OutField:       fieldName,
+			})
+		}
+	}
+
+	return &individualRetriever{
+		metrics:              requestMetrics,
+		useIntegerConversion: useIntegerConversion,
+	}
+}
+
+// NewBulkRetriever creates a new bulk retriever
+func NewBulkRetriever(useIntegerConversion bool, configuredMetrics []ConfiguredMetric) (Retriever, error) {
+	requestMetrics := make([]BulkRequestMetrics, 0)
+
+	for _, configMetric := range configuredMetrics {
+		bulkRequest := BulkRequestMetrics{
+			IDs:            make([]string, 0, len(configMetric.Fields)),
+			Parameters:     toRequestParameters(configMetric.Parameters),
+			OutMeasurement: configMetric.Name,
+			OutFields:      make(map[string]string, len(configMetric.Fields)),
+		}
+
+		for fieldName, fieldPath := range configMetric.Fields {
+			requestID := "/" + fieldPath
+			bulkRequest.IDs = append(bulkRequest.IDs, requestID)
+			bulkRequest.OutFields[requestID] = fieldName
+		}
+
+		var err error
+		bulkRequest.RequestBody, err = json.Marshal(bulkRequest)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request body for measurment '%s': %w", configMetric.Name, err)
+		}
+
+		requestMetrics = append(requestMetrics, bulkRequest)
+	}
+
+	return &bulkRetriever{
+		metrics:              requestMetrics,
+		useIntegerConversion: useIntegerConversion,
+	}, nil
+}
+
+type individualRetriever struct {
+	metrics              []RequestMetric
+	useIntegerConversion bool
+}
+
+func (r *individualRetriever) RequestCount() int {
+	return len(r.metrics)
+}
+
+func (r *individualRetriever) Describe(index int) string {
+	return fmt.Sprintf("metric %s", r.metrics[index].ID)
+}
+
+func (r *individualRetriever) CreateRequest(index int, baseURL string) (*http.Request, error) {
+	metric := r.metrics[index]
+
+	content := struct {
+		Parameters []RequestParameter `json:"parameters,omitempty"`
+	}{
+		metric.Parameters,
+	}
+
+	body, err := json.Marshal(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request body for metric '%s': %w", metric.ID, err)
+	}
+
+	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for metric '%s': %w", metric.ID, err)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+
+	return request, nil
+}
+
+func (r *individualRetriever) PopulateResponse(index int, acc telegraf.Accumulator, responseMetrics []ResponseMetric, timestamp time.Time) {
+	metric := r.metrics[index]
+	for _, responseMetric := range responseMetrics {
+		for _, permutation := range responseMetric.Permutations {
+			if permutation.Value == nil {
+				continue
+			}
+
+			tags := make(map[string]string)
+			for _, parameter := range permutation.Parameters {
+				tags[parameter.Name] = parameter.Value
+			}
+
+			acc.AddFields(
+				metric.OutMeasurement,
+				map[string]interface{}{metric.OutField: tryNumericConversion(
+					r.useIntegerConversion,
+					*permutation.Value),
+				},
+				tags,
+				timestamp,
+			)
+		}
+	}
+}
+
+type bulkRetriever struct {
+	metrics              []BulkRequestMetrics
+	useIntegerConversion bool
+}
+
+func (r *bulkRetriever) RequestCount() int {
+	return len(r.metrics)
+}
+
+func (r *bulkRetriever) Describe(index int) string {
+	return fmt.Sprintf("measurement %s", r.metrics[index].OutMeasurement)
+}
+
+func (r *bulkRetriever) CreateRequest(index int, baseURL string) (*http.Request, error) {
+	metrics := r.metrics[index]
+	request, err := http.NewRequest("POST", baseURL, bytes.NewReader(metrics.RequestBody))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for measurement '%s': %w", metrics.OutMeasurement, err)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+
+	return request, nil
+}
+
+func (r *bulkRetriever) PopulateResponse(index int, acc telegraf.Accumulator, responseMetrics []ResponseMetric, timestamp time.Time) {
+	metrics := r.metrics[index]
+	for _, responseMetric := range responseMetrics {
+		outField, ok := metrics.OutFields[responseMetric.ID]
+		if !ok {
+			acc.AddError(fmt.Errorf("response contained unexpected metric: %s", responseMetric.ID))
+			continue
+		}
+
+		for _, permutation := range responseMetric.Permutations {
+			if permutation.Value == nil {
+				continue
+			}
+
+			tags := make(map[string]string)
+			for _, parameter := range permutation.Parameters {
+				tags[parameter.Name] = parameter.Value
+			}
+
+			acc.AddFields(
+				metrics.OutMeasurement,
+				map[string]interface{}{outField: tryNumericConversion(
+					r.useIntegerConversion,
+					*permutation.Value),
+				},
+				tags,
+				timestamp,
+			)
+		}
+	}
+}
+
+func toRequestParameters(configParameters map[string][]string) []RequestParameter {
+	// Sort names for consistency in testing. It's not free, but only happens during startup.
+	parameterNames := make([]string, 0, len(configParameters))
+	for parameterName := range configParameters {
+		parameterNames = append(parameterNames, parameterName)
+	}
+	sort.Strings(parameterNames)
+
+	parameters := make([]RequestParameter, 0, len(configParameters))
+	for _, parameterName := range parameterNames {
+		values := configParameters[parameterName]
+		parameters = append(parameters, RequestParameter{
+			Name:    parameterName,
+			Values:  values,
+			Itemize: true,
+		})
+	}
+
+	return parameters
+}
+
+func tryNumericConversion(useIntegerConversion bool, value string) interface{} {
+	if useIntegerConversion {
+		if i, err := strconv.Atoi(value); err == nil {
+			return i
+		}
+	}
+
+	if f, err := strconv.ParseFloat(value, 64); err == nil {
+		return f
+	}
+
+	return value
+}

--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -1,15 +1,12 @@
 package t128_metrics
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
-	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -33,10 +30,11 @@ type T128Metrics struct {
 	Timeout                 internal.Duration  `toml:"timeout"`
 	MaxSimultaneousRequests int                `toml:"max_simultaneous_requests"`
 	UseIntegerConversion    bool               `toml:"use_integer_conversion"`
+	UseBulkRetrieval        bool               `toml:"use_bulk_retrieval"`
 
-	client  *http.Client
-	limiter *requestLimiter
-	metrics []RequestMetric
+	client    *http.Client
+	limiter   *requestLimiter
+	retriever Retriever
 }
 
 // ConfiguredMetric represents a single configured metric element
@@ -54,6 +52,10 @@ var sampleConfig = `
 
 ## A socket to use for retrieving metrics - unused by default
 # unix_socket = "/var/run/128technology/web-server.sock"
+
+## Whether or not to use the bulk retrieval API. If used, the base_url should
+## point directly to the bulk metrics endpoint.
+# use_bulk_retrieval = false
 
 ## The maximum number of requests to be in flight at once
 # max_simultaneous_requests = 20
@@ -94,7 +96,7 @@ func (plugin *T128Metrics) Init() error {
 		return fmt.Errorf("base_url is a required configuration field")
 	}
 
-	if plugin.BaseURL[len(plugin.BaseURL)-1:] != "/" {
+	if !plugin.UseBulkRetrieval && plugin.BaseURL[len(plugin.BaseURL)-1:] != "/" {
 		plugin.BaseURL += "/"
 	}
 
@@ -114,7 +116,16 @@ func (plugin *T128Metrics) Init() error {
 
 	plugin.client = &http.Client{Transport: transport, Timeout: plugin.Timeout.Duration}
 	plugin.limiter = newRequestLimiter(plugin.MaxSimultaneousRequests)
-	plugin.metrics = configuredMetricsToRequestMetrics(plugin.ConfiguredMetrics)
+
+	if plugin.UseBulkRetrieval {
+		var err error
+		plugin.retriever, err = NewBulkRetriever(plugin.UseIntegerConversion, plugin.ConfiguredMetrics)
+		if err != nil {
+			return fmt.Errorf("failed to create retriever: %w", err)
+		}
+	} else {
+		plugin.retriever = NewIndividualRetriever(plugin.UseIntegerConversion, plugin.ConfiguredMetrics)
+	}
 
 	return nil
 }
@@ -125,13 +136,13 @@ func (plugin *T128Metrics) Gather(acc telegraf.Accumulator) error {
 	timestamp := time.Now().Round(time.Second)
 
 	var wg sync.WaitGroup
-	wg.Add(len(plugin.metrics))
+	wg.Add(plugin.retriever.RequestCount())
 
-	for _, requestMetric := range plugin.metrics {
-		go func(metric RequestMetric) {
-			plugin.retrieveMetric(metric, acc, timestamp)
+	for index := 0; index < plugin.retriever.RequestCount(); index++ {
+		go func(idx int) {
+			plugin.retrieveMetrics(idx, acc, timestamp)
 			wg.Done()
-		}(requestMetric)
+		}(index)
 	}
 
 	wg.Wait()
@@ -139,10 +150,10 @@ func (plugin *T128Metrics) Gather(acc telegraf.Accumulator) error {
 	return nil
 }
 
-func (plugin *T128Metrics) retrieveMetric(metric RequestMetric, acc telegraf.Accumulator, timestamp time.Time) {
-	request, err := plugin.createRequest(plugin.BaseURL, metric)
+func (plugin *T128Metrics) retrieveMetrics(index int, acc telegraf.Accumulator, timestamp time.Time) {
+	request, err := plugin.retriever.CreateRequest(index, plugin.BaseURL)
 	if err != nil {
-		acc.AddError(fmt.Errorf("failed to create a request for metric %s: %w", metric.ID, err))
+		acc.AddError(fmt.Errorf("failed to create a request for %s: %w", plugin.retriever.Describe(index), err))
 		return
 	}
 
@@ -151,7 +162,7 @@ func (plugin *T128Metrics) retrieveMetric(metric RequestMetric, acc telegraf.Acc
 	plugin.limiter.done()
 
 	if err != nil {
-		acc.AddError(fmt.Errorf("failed to retrieve metric %s: %w", metric.ID, err))
+		acc.AddError(fmt.Errorf("failed to retrieve %s: %w", plugin.retriever.Describe(index), err))
 		return
 	}
 	defer response.Body.Close()
@@ -162,107 +173,17 @@ func (plugin *T128Metrics) retrieveMetric(metric RequestMetric, acc telegraf.Acc
 			message = []byte("")
 		}
 
-		acc.AddError(fmt.Errorf("status code %d not OK for metric %s: %s", response.StatusCode, metric.ID, message))
+		acc.AddError(fmt.Errorf("status code %d not OK for %s: %s", response.StatusCode, plugin.retriever.Describe(index), message))
 		return
 	}
 
 	var responseMetrics []ResponseMetric
 	if err := json.NewDecoder(response.Body).Decode(&responseMetrics); err != nil {
-		acc.AddError(fmt.Errorf("failed to decode response for metric %s: %w", metric.ID, err))
+		acc.AddError(fmt.Errorf("failed to decode response for %s: %w", plugin.retriever.Describe(index), err))
 		return
 	}
 
-	for _, responseMetric := range responseMetrics {
-		for _, permutation := range responseMetric.Permutations {
-			if permutation.Value == nil {
-				continue
-			}
-
-			tags := make(map[string]string)
-			for _, parameter := range permutation.Parameters {
-				tags[parameter.Name] = parameter.Value
-			}
-
-			acc.AddFields(
-				metric.OutMeasurement,
-				map[string]interface{}{metric.OutField: tryNumericConversion(
-					plugin.UseIntegerConversion,
-					*permutation.Value),
-				},
-				tags,
-				timestamp)
-		}
-	}
-}
-
-func (plugin *T128Metrics) createRequest(baseURL string, metric RequestMetric) (*http.Request, error) {
-	content := struct {
-		Parameters []RequestParameter `json:"parameters,omitempty"`
-	}{
-		metric.Parameters,
-	}
-
-	body, err := json.Marshal(content)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request body for metric '%s': %w", metric.ID, err)
-	}
-
-	request, err := http.NewRequest("POST", fmt.Sprintf("%s%s", baseURL, metric.ID), bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request for metric '%s': %w", metric.ID, err)
-	}
-
-	request.Header.Add("Content-Type", "application/json")
-
-	return request, nil
-}
-
-func configuredMetricsToRequestMetrics(configuredMetrics []ConfiguredMetric) []RequestMetric {
-	requestMetrics := make([]RequestMetric, 0)
-
-	for _, configMetric := range configuredMetrics {
-		for fieldName, fieldPath := range configMetric.Fields {
-			// Sort names for consistency in testing. It's not free, but only happens during startup.
-			parameterNames := make([]string, 0, len(configMetric.Parameters))
-			for parameterName := range configMetric.Parameters {
-				parameterNames = append(parameterNames, parameterName)
-			}
-			sort.Strings(parameterNames)
-
-			parameters := make([]RequestParameter, 0, len(configMetric.Parameters))
-			for _, parameterName := range parameterNames {
-				values := configMetric.Parameters[parameterName]
-				parameters = append(parameters, RequestParameter{
-					Name:    parameterName,
-					Values:  values,
-					Itemize: true,
-				})
-			}
-
-			requestMetrics = append(requestMetrics, RequestMetric{
-				ID:             fieldPath,
-				Parameters:     parameters,
-				OutMeasurement: configMetric.Name,
-				OutField:       fieldName,
-			})
-		}
-	}
-
-	return requestMetrics
-}
-
-func tryNumericConversion(useIntegerConversion bool, value string) interface{} {
-	if useIntegerConversion {
-		if i, err := strconv.Atoi(value); err == nil {
-			return i
-		}
-	}
-
-	if f, err := strconv.ParseFloat(value, 64); err == nil {
-		return f
-	}
-
-	return value
+	plugin.retriever.PopulateResponse(index, acc, responseMetrics, timestamp)
 }
 
 type requestLimiter struct {
@@ -293,6 +214,7 @@ func init() {
 			Timeout:                 internal.Duration{Duration: DefaultRequestTimeout},
 			MaxSimultaneousRequests: DefaultMaxSimultaneousRequests,
 			UseIntegerConversion:    false,
+			UseBulkRetrieval:        false,
 		}
 	})
 }

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -32,9 +32,18 @@ var ResponseProcessingTestCases = []struct {
 	ExpectedMetrics   []*testutil.Metric
 	ExpectedErrors    []string
 	IntegerConversion bool
+	BulkRetrieval     bool
 }{
 	{
 		Name:              "empty configured metrics produce no requests or metrics",
+		ConfiguredMetrics: []plugin.ConfiguredMetric{},
+		Endpoints:         []Endpoint{},
+		ExpectedMetrics:   nil,
+		ExpectedErrors:    nil,
+	},
+	{
+		Name:              "empty configured metrics produce no requests or metrics bulk",
+		BulkRetrieval:     true,
 		ConfiguredMetrics: []plugin.ConfiguredMetric{},
 		Endpoints:         []Endpoint{},
 		ExpectedMetrics:   nil,
@@ -48,6 +57,18 @@ var ResponseProcessingTestCases = []struct {
 			map[string][]string{},
 		}},
 		Endpoints:       []Endpoint{{"/stats/test", 200, "{}", "[]"}},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  nil,
+	},
+	{
+		Name:          "empty results produce no metrics bulk",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints:       []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, "[]"}},
 		ExpectedMetrics: nil,
 		ExpectedErrors:  nil,
 	},
@@ -69,6 +90,24 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedErrors:  nil,
 	},
 	{
+		Name:          "none value produces no metric bulk",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, `[{
+			"id": "/stats/test",
+			"permutations": [{
+				"parameters": [],
+				"value": null
+			}]
+		}]`}},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  nil,
+	},
+	{
 		Name: "forms string value if it is non numeric",
 		ConfiguredMetrics: []plugin.ConfiguredMetric{{
 			"test-metric",
@@ -77,6 +116,30 @@ var ResponseProcessingTestCases = []struct {
 		}},
 		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
 			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "test-string"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": "test-string"},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:          "forms string value if it is non numeric bulk",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, `[{
+			"id": "/stats/test",
 			"permutations": [{
 				"parameters": [],
 				"value": "test-string"
@@ -116,6 +179,31 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedErrors: nil,
 	},
 	{
+		Name:              "forms float value if integer conversion is disabled bulk",
+		BulkRetrieval:     true,
+		IntegerConversion: false,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, `[{
+			"id": "/stats/test",
+			"permutations": [{
+				"parameters": [],
+				"value": "50"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50.0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
 		Name:              "forms integer value if integer conversion is enabled",
 		IntegerConversion: true,
 		ConfiguredMetrics: []plugin.ConfiguredMetric{{
@@ -140,6 +228,31 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedErrors: nil,
 	},
 	{
+		Name:              "forms integer value if integer conversion is enabled bulk",
+		BulkRetrieval:     true,
+		IntegerConversion: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, `[{
+			"id": "/stats/test",
+			"permutations": [{
+				"parameters": [],
+				"value": "50"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
 		Name: "forms float value if it is a float",
 		ConfiguredMetrics: []plugin.ConfiguredMetric{{
 			"test-metric",
@@ -148,6 +261,30 @@ var ResponseProcessingTestCases = []struct {
 		}},
 		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
 			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50.5"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50.5},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:          "forms float value if it is a float bulk",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, `[{
+			"id": "/stats/test",
 			"permutations": [{
 				"parameters": [],
 				"value": "50.5"
@@ -196,6 +333,40 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedErrors: nil,
 	},
 	{
+		Name:              "adds permutation parameters to metrics bulk",
+		BulkRetrieval:     true,
+		IntegerConversion: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, `[{
+			"id": "/stats/test",
+			"permutations": [{
+				"parameters": [
+					{
+						"name": "node",
+						"value": "node1"
+					},
+					{
+						"name": "interface",
+						"value": "intf1"
+					}
+				],
+				"value": "0"
+			}]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node1", "interface": "intf1"},
+				Fields:      map[string]interface{}{"test-field": 0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
 		Name:              "produces multiple metrics for multiple permutations",
 		IntegerConversion: true,
 		ConfiguredMetrics: []plugin.ConfiguredMetric{{
@@ -204,6 +375,52 @@ var ResponseProcessingTestCases = []struct {
 			map[string][]string{},
 		}},
 		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test",
+			"permutations": [
+				{
+					"parameters": [
+						{
+							"name": "node",
+							"value": "node1"
+						}
+					],
+					"value": "897"
+				},
+				{
+					"parameters": [
+						{
+							"name": "node",
+							"value": "node2"
+						}
+					],
+					"value": "306"
+				}
+			]
+		}]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node1"},
+				Fields:      map[string]interface{}{"test-field": 897},
+			},
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"node": "node2"},
+				Fields:      map[string]interface{}{"test-field": 306},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:              "produces multiple metrics for multiple permutations bulk",
+		BulkRetrieval:     true,
+		IntegerConversion: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, `[{
 			"id": "/stats/test",
 			"permutations": [
 				{
@@ -281,6 +498,46 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedErrors: nil,
 	},
 	{
+		Name:              "requests bulk in single request",
+		BulkRetrieval:     true,
+		IntegerConversion: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{
+				"test-field":         "stats/test",
+				"another-test-field": "stats/another/test",
+			},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test", "/stats/another/test"]}`, `[{
+				"id": "/stats/test",
+				"permutations": [{
+					"parameters": [],
+					"value": "50"
+				}]
+			}, {
+				"id": "/stats/another/test",
+				"permutations": [{
+					"parameters": [],
+					"value": "60"
+				}]
+			}
+		]`}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"another-test-field": 60},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
 		Name: "propogates errors to accumulator",
 		ConfiguredMetrics: []plugin.ConfiguredMetric{{
 			"404",
@@ -346,6 +603,7 @@ var RequestFormationTestCases = []struct {
 	Name              string
 	ConfiguredMetrics []plugin.ConfiguredMetric
 	Endpoints         []Endpoint
+	BulkRetrieval     bool
 }{
 	{
 		Name: "empty request body with no parameters",
@@ -357,6 +615,16 @@ var RequestFormationTestCases = []struct {
 		Endpoints: []Endpoint{{"/stats/test", 200, "{}", "[]"}},
 	},
 	{
+		Name:          "empty request body with no parameters bulk",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, "[]"}},
+	},
+	{
 		Name: "itemizes with no filter values for empty list",
 		ConfiguredMetrics: []plugin.ConfiguredMetric{{
 			"test-metric",
@@ -366,6 +634,20 @@ var RequestFormationTestCases = []struct {
 		Endpoints: []Endpoint{{"/stats/test", 200, `{"parameters": [{"name": "interface", "itemize": true}]}`, "[]"}},
 	},
 	{
+		Name:          "itemizes with no filter values for empty list bulk",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{"interface": {}},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{
+				"ids": ["/stats/test"],
+				"parameters": [{"name": "interface", "itemize": true}]
+			}`,
+			"[]"}},
+	},
+	{
 		Name: "includes parameter filter values",
 		ConfiguredMetrics: []plugin.ConfiguredMetric{{
 			"test-metric",
@@ -373,6 +655,22 @@ var RequestFormationTestCases = []struct {
 			map[string][]string{"interface": {"intf1", "intf2"}},
 		}},
 		Endpoints: []Endpoint{{"/stats/test", 200, `{
+				"parameters": [
+					{"name": "interface", "values": ["intf1", "intf2"], "itemize": true}
+				]
+			}`,
+			"[]"}},
+	},
+	{
+		Name:          "includes parameter filter values bulk",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{"interface": {"intf1", "intf2"}},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{
+				"ids": ["/stats/test"],
 				"parameters": [
 					{"name": "interface", "values": ["intf1", "intf2"], "itemize": true}
 				]
@@ -398,6 +696,27 @@ var RequestFormationTestCases = []struct {
 			}`,
 			"[]"}},
 	},
+	{
+		Name:          "includes multiple parameter filters",
+		BulkRetrieval: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{
+				"interface": {"intf1", "intf2"},
+				"node":      {"node1", "node2"},
+				"other":     {}},
+		}},
+		Endpoints: []Endpoint{{"/", 200, `{
+				"ids": ["/stats/test"],
+				"parameters": [
+					{"name": "interface", "values": ["intf1", "intf2"], "itemize": true},
+					{"name": "node", "values": ["node1", "node2"], "itemize": true},
+					{"name": "other", "itemize": true}
+				]
+			}`,
+			"[]"}},
+	},
 }
 
 func TestT128MetricsResponseProcessing(t *testing.T) {
@@ -411,6 +730,7 @@ func TestT128MetricsResponseProcessing(t *testing.T) {
 				MaxSimultaneousRequests: 20,
 				ConfiguredMetrics:       testCase.ConfiguredMetrics,
 				UseIntegerConversion:    testCase.IntegerConversion,
+				UseBulkRetrieval:        testCase.BulkRetrieval,
 			}
 
 			var acc testutil.Accumulator
@@ -450,6 +770,7 @@ func TestT128MetricsRequestFormation(t *testing.T) {
 				BaseURL:                 fakeServer.URL,
 				MaxSimultaneousRequests: 20,
 				ConfiguredMetrics:       testCase.ConfiguredMetrics,
+				UseBulkRetrieval:        testCase.BulkRetrieval,
 			}
 
 			var acc testutil.Accumulator
@@ -562,6 +883,7 @@ func TestLoadsFromToml(t *testing.T) {
 	exampleConfig := []byte(`
 		base_url                    = "example/base/url/"
 		unix_socket                 = "example.sock"
+		use_bulk_retrieval    		= true
 		max_simultaneous_requests   = 15
 		timeout                     = "500ms"
 		use_integer_conversion		= true
@@ -579,6 +901,7 @@ func TestLoadsFromToml(t *testing.T) {
 	require.Equal(t, 500*time.Millisecond, plugin.Timeout.Duration)
 	require.Equal(t, expectedMetrics, plugin.ConfiguredMetrics)
 	require.True(t, plugin.UseIntegerConversion)
+	require.True(t, plugin.UseBulkRetrieval)
 }
 
 func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
@@ -595,6 +918,7 @@ func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
 
 		endpoint, ok := endpoints[r.URL.Path]
 		if !ok {
+			fmt.Printf("There isn't an endpoint for: %v\n", r.URL.Path)
 			w.WriteHeader(404)
 			return
 		}


### PR DESCRIPTION
## Description

The `t128_metrics` input has been retrieving data for each metric individually by hitting the REST endpoint for each. It has become clear that approach won't scale. Instead, an API will be exposed that allows any number of groupable metrics to be retrieved in a single request. The implementation is such that each `[[inputs.t128_metrics.metric]]` instance will correspond to a single request rather than each field within a metric producing a request.

## Corresponding Changes

1. The Monitoring Agent will have changes to configure the input with this feature
2. MARS will require some changes to expose the API as needed

## Testing

I verified the functionality on a system that has a POC version of the MARS changes. I've also added unit tests.

The improvement is drastic. The `Bulk Retrieval` indicates where bulk retrieval begins and `Individual Retrieval` indicates where the switch is made to the old approach. This is retrieving all **369** per node metrics in the highway.

![collector_improvement](https://user-images.githubusercontent.com/22240266/105910408-e72cd280-5ff6-11eb-9ab8-e605253077ea.png)
