### PR TITLE
Base branch for graph collector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.9.3
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Jeffail/gabs v1.4.0
 	github.com/Mellanox/rdmamap v0.0.0-20191106181932-7c3c4763a6ee
 	github.com/Microsoft/ApplicationInsights-Go v0.4.2
 	github.com/Microsoft/go-winio v0.4.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/Jeffail/gabs v1.4.0 h1://5fYRRTq1edjfIrQGvdkcd22pkYUrHZ5YC/H2GJVAo=
+github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
 github.com/Mellanox/rdmamap v0.0.0-20191106181932-7c3c4763a6ee h1:atI/FFjXh6hIVlPE1Jup9m8N4B9q/OSbMUe2EBahs+w=
 github.com/Mellanox/rdmamap v0.0.0-20191106181932-7c3c4763a6ee/go.mod h1:jDA6v0TUYrFEIAE5uGJ29LQOeONIgMdP4Rkqb8HUnPM=
 github.com/Microsoft/ApplicationInsights-Go v0.4.2 h1:HIZoGXMiKNwAtMAgCSSX35j9mP+DjGF9ezfBvxMDLLg=

--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -165,6 +165,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/sysstat"
 	_ "github.com/influxdata/telegraf/plugins/inputs/system"
 	_ "github.com/influxdata/telegraf/plugins/inputs/systemd_units"
+	_ "github.com/influxdata/telegraf/plugins/inputs/t128_graphql"
 	_ "github.com/influxdata/telegraf/plugins/inputs/t128_metrics"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tail"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tcp_listener"

--- a/plugins/inputs/t128_graphql/query_builder.go
+++ b/plugins/inputs/t128_graphql/query_builder.go
@@ -1,0 +1,20 @@
+package t128_graphql
+
+import "strings"
+
+func buildQuery(entryPoint string, fields map[string]string, tags map[string]string) string {
+	var replacer = strings.NewReplacer("[", "(", "]", "\")", "/", "{", ":", ":\"")
+	query := "query {" + replacer.Replace(entryPoint) + "{"
+
+	for _, element := range fields {
+		query += "\n" + element
+	}
+	query = strings.TrimSpace(query)
+	for _, element := range tags {
+		query += "\n" + element
+	}
+
+	query += "\n" + strings.Repeat("}", strings.Count(query, "{"))
+
+	return query
+}

--- a/plugins/inputs/t128_graphql/sample.go
+++ b/plugins/inputs/t128_graphql/sample.go
@@ -1,0 +1,34 @@
+package t128_graphql
+
+var sampleConfig = `
+## Collect data using graphQL
+[[inputs.t128_graphql]]
+## Required. The telegraf collector name
+# collector_name = "arp-state"
+
+## Required. GraphQL ports vary across 128T versions
+# base_url = "http://localhost:31517/api/v1/graphql/"
+
+## A socket to use for retrieving metrics - unused by default
+# unix_socket = "/var/run/128technology/web-server.sock"
+
+## The starting point in the graphQL tree for all configured tags and fields
+# entry_point = "allRouters[name:RTR_WEST_COMBO]/nodes/nodes[name:combo-west]/nodes/arp/nodes"
+
+## Amount of time allowed to complete a single HTTP request
+# timeout = "5s"
+
+## The fields to collect with the desired name as the key (left) and graphQL 
+## key as the value (right)
+# [inputs.t128_graphql.extract_fields]
+#   state = "state"
+
+## The tags for filtering data with the desired name as the key (left) and 
+## graphQL key as the value (right)
+# [inputs.t128_graphql.extract_tags]
+#   network-interface = "networkInterface"
+#   device-interface = "deviceInterface"
+#   vlan = "vlan"
+#   ip-address = "ipAddress"
+#   destination-mac = "destinationMac"
+`

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -1,0 +1,284 @@
+package t128_graphql
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Jeffail/gabs"
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+const (
+	//make this configurable?
+	DefaultRequestTimeout = time.Second * 5
+)
+
+type T128GraphQL struct {
+	CollectorName string            `toml:"collector_name"`
+	BaseURL       string            `toml:"base_url"`
+	EntryPoint    string            `toml:"entry_point"`
+	Fields        map[string]string `toml:"extract_fields"`
+	Tags          map[string]string `toml:"extract_tags"`
+
+	Client *http.Client
+	Query  string
+}
+
+var sampleConfig = `
+## Collect data using graphQL
+[[inputs.t128_graphql]]
+## Required. The telegraf collector name
+# collector_name = "arp-state"
+
+## Required. GraphQL ports vary across 128T versions
+# base_url = "http://localhost:31517"
+
+## The starting point in the graphQL tree for all configured tags and fields
+# entry_point = "allRouters[name:RTR_WEST_COMBO]/nodes/nodes[name:combo-west]/nodes/arp/nodes"
+
+## The fields to collect with the desired name as the key (left) and graphQL 
+## key as the value (right)
+# [inputs.t128_graphql.extract_fields]
+#   state = "state"
+
+## The tags for filtering data with the desired name as the key (left) and 
+## graphQL key as the value (right)
+# [inputs.t128_graphql.extract_tags]
+#   networkInterface = "networkInterface"
+#   deviceInterface = "deviceInterface"
+#   vlan = "vlan"
+#   ipAddress = "ipAddress"
+#   destinationMac = "destinationMac"
+`
+
+func (*T128GraphQL) SampleConfig() string {
+	return sampleConfig
+}
+
+func (*T128GraphQL) Description() string {
+	return "Read data from a graphQL query"
+}
+
+func (plugin *T128GraphQL) Init() error {
+	if plugin.CollectorName == "" {
+		return fmt.Errorf("collector_name is a required configuration field")
+	}
+
+	if plugin.BaseURL == "" {
+		return fmt.Errorf("base_url is a required configuration field")
+	}
+
+	if plugin.BaseURL[len(plugin.BaseURL)-1:] != "/" {
+		plugin.BaseURL += "/"
+	}
+
+	transport := http.DefaultTransport
+
+	plugin.Client = &http.Client{Transport: transport, Timeout: DefaultRequestTimeout}
+	plugin.Query = plugin.buildQuery()
+
+	return nil
+}
+
+func (plugin *T128GraphQL) Gather(acc telegraf.Accumulator) error {
+	timestamp := time.Now().Round(time.Second)
+
+	plugin.retrieveMetrics(acc, timestamp)
+
+	return nil
+}
+
+func (plugin *T128GraphQL) buildQuery() string {
+	//allow multiple inputs like names[ComboEast,ComboWest] ?
+	var replacer = strings.NewReplacer("[", "(", "]", "\")", "/", "{", ":", ":\"")
+	query := "query MyQuery{" + replacer.Replace(plugin.EntryPoint) + "{"
+
+	for _, element := range plugin.Fields {
+		query += "\n" + element
+	}
+	query = strings.TrimSpace(query)
+	for _, element := range plugin.Tags {
+		query += "\n" + element
+	}
+
+	query += "\n" + strings.Repeat("}", strings.Count(query, "{"))
+
+	return query
+}
+
+func (plugin *T128GraphQL) retrieveMetrics(acc telegraf.Accumulator, timestamp time.Time) {
+	request, err := plugin.createRequest()
+	if err != nil {
+		acc.AddError(fmt.Errorf("failed to create a request for query %s: %w", plugin.Query, err))
+		return
+	}
+
+	response, err := plugin.Client.Do(request)
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(response.Body)
+
+	if err != nil {
+		template := "query error for metric %s: %s"
+		plugin.DecodeAndReportJsonErrors(buf.Bytes(), acc, template)
+		return
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		template := fmt.Sprintf("status code %d not OK for metric ", response.StatusCode) + "%s: %s"
+		plugin.DecodeAndReportJsonErrors(buf.Bytes(), acc, template)
+		return
+	}
+
+	//decode json
+	jsonParsed, err := gabs.ParseJSON(buf.Bytes())
+	if err != nil {
+		acc.AddError(fmt.Errorf("invalid json response for metric %s: %w", plugin.CollectorName, err))
+		return
+	}
+
+	jsonEntryPoint := plugin.BuildJsonEntryPoint()
+	jsonObj, err := jsonParsed.JSONPointer(jsonEntryPoint)
+	if err != nil {
+		template := "unexpected response for metric %s: %s"
+		plugin.DecodeAndReportJsonErrors(buf.Bytes(), acc, template)
+		return
+	}
+
+	//update acc
+	jsonChildren, err := jsonObj.Children()
+	if err != nil {
+		acc.AddError(fmt.Errorf("failed to iterate on response nodes for metric %s: %w", plugin.CollectorName, err))
+		return
+	}
+
+	//TODO: allow nested fields/tags
+	for _, child := range jsonChildren {
+		node := child.Data().(map[string]interface{})
+		fields := make(map[string]interface{})
+		tags := make(map[string]string)
+
+		//allow integer conversion?
+		//TODO: fully implement multiple fields
+		for fieldRenamed, fieldName := range plugin.Fields {
+			if isNil(node[fieldName]) {
+				acc.AddError(fmt.Errorf("found empty data for metric %s: field %s", plugin.CollectorName, fieldName))
+				continue
+			}
+			fields[fieldRenamed] = node[fieldName]
+
+			for tagRenamed, tagName := range plugin.Tags {
+				if isNil(node[tagName]) {
+					tags[tagRenamed] = tagRenamed
+					continue
+				}
+				//gabs module converts data to either string or float64
+				strTag, ok := node[tagName].(string)
+				if !ok {
+					floatTag := node[tagName].(float64)
+					strTag = strconv.FormatFloat(floatTag, 'f', -1, 64)
+				}
+				tags[tagRenamed] = strTag
+			}
+
+			acc.AddFields(
+				plugin.CollectorName,
+				fields,
+				tags,
+				timestamp,
+			)
+		}
+	}
+}
+
+func (plugin *T128GraphQL) createRequest() (*http.Request, error) {
+	content := struct {
+		Query string `json:"query,omitempty"`
+	}{
+		plugin.Query,
+	}
+
+	//inject env config?
+	body, err := json.Marshal(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request body for query '%s': %w", plugin.Query, err)
+	}
+
+	url := plugin.BaseURL + "api/v1/graphql"
+	request, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request for query '%s': %w", plugin.Query, err)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+
+	return request, nil
+}
+
+func (plugin *T128GraphQL) BuildJsonEntryPoint() string {
+	path := "/data/"
+	pathElements := strings.Split(plugin.EntryPoint, "/")
+	for idx, element := range pathElements {
+		bracketIdx := strings.Index(element, "[")
+		if bracketIdx > 0 {
+			path += element[:bracketIdx] + "/"
+		} else {
+			if idx < len(pathElements)-2 {
+				path += element + "/0/"
+			} else {
+				path += element + "/"
+			}
+		}
+	}
+	path = strings.TrimRight(path, "/")
+	return path
+}
+
+func (plugin *T128GraphQL) DecodeAndReportJsonErrors(response []byte, acc telegraf.Accumulator, template string) {
+	parsedJSON, err := gabs.ParseJSON(response)
+	if err != nil {
+		acc.AddError(fmt.Errorf(template, plugin.CollectorName, response))
+		return
+	}
+
+	jsonObj, err := parsedJSON.JSONPointer("/errors")
+	if err != nil {
+		acc.AddError(fmt.Errorf(template, plugin.CollectorName, parsedJSON.String()))
+		return
+	}
+
+	jsonChildren, err := jsonObj.Children()
+	if err != nil {
+		acc.AddError(fmt.Errorf(template, plugin.CollectorName, parsedJSON.String()))
+		return
+	}
+
+	for _, child := range jsonChildren {
+		errorNode := child.Data().(map[string]interface{})
+		acc.AddError(fmt.Errorf(template, plugin.CollectorName, errorNode["message"].(string)))
+	}
+}
+
+func isNil(i interface{}) bool {
+	if i == nil {
+		return true
+	}
+	switch reflect.TypeOf(i).Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
+		return reflect.ValueOf(i).IsNil()
+	}
+	return false
+}
+
+func init() {
+	inputs.Add("t128_graphql", func() telegraf.Input {
+		return &T128GraphQL{}
+	})
+}

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -35,6 +35,7 @@ const (
 	InvalidFieldQuery             = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ninvalid-field\n}}}}}}}"
 )
 
+//TODO: more unit tests - MON-314
 var ResponseProcessingTestCases = []struct {
 	Name            string
 	EntryPoint      string
@@ -378,6 +379,23 @@ var QueryFormationTestCases = []struct {
 	},
 }
 
+//TODO: more unit tests - MON-314
+var JSONPathFormationTestCases = []struct {
+	Name                   string
+	EntryPoint             string
+	Fields                 map[string]string
+	Tags                   map[string]string
+	ExpectedJSONEntryPoint string
+}{
+	{
+		Name:                   "build arp state json path",
+		EntryPoint:             "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:                 map[string]string{"test-field": "test-field"},
+		Tags:                   map[string]string{},
+		ExpectedJSONEntryPoint: "/data/allRouters/nodes/0/nodes/nodes/0/arp/nodes",
+	},
+}
+
 func TestT128GraphqlResponseProcessing(t *testing.T) {
 	for _, testCase := range ResponseProcessingTestCases {
 		t.Run(testCase.Name, func(t *testing.T) {
@@ -439,6 +457,23 @@ func TestT128GraphqlQueryFormation(t *testing.T) {
 
 			require.NoError(t, plugin.Init())
 			require.Equal(t, testCase.ExpectedQuery, plugin.Query)
+		})
+	}
+}
+
+func TestT128GraphqlJSONPathFormation(t *testing.T) {
+	for _, testCase := range JSONPathFormationTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			plugin := &plugin.T128GraphQL{
+				CollectorName: "test-collector",
+				BaseURL:       "/api/v1/graphql",
+				EntryPoint:    testCase.EntryPoint,
+				Fields:        testCase.Fields,
+				Tags:          testCase.Tags,
+			}
+
+			require.NoError(t, plugin.Init())
+			require.Equal(t, testCase.ExpectedJSONEntryPoint, plugin.JSONEntryPoint)
 		})
 	}
 }

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -23,16 +23,16 @@ type Endpoint struct {
 }
 
 const (
-	ValidExpectedRequestNoTag     = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"}`
-	ValidQueryNoTag               = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"
-	ValidExpectedRequestSingleTag = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"}`
-	ValidQuerySingleTag           = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"
-	ValidExpectedRequestDoubleTag = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag-1\ntest-tag-2\n}}}}}}}"}`
-	ValidQueryDoubleTag           = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag-1\ntest-tag-2\n}}}}}}}"
-	InvalidRouterExpectedRequest  = `{"query":"query {allRouters(name:\"not-a-router\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"}`
-	InvalidRouterQuery            = "query {allRouters(name:\"not-a-router\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"
-	InvalidFieldExpectedRequest   = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ninvalid-field\n}}}}}}}"}`
-	InvalidFieldQuery             = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ninvalid-field\n}}}}}}}"
+	ValidExpectedRequestSingleTag   = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"}`
+	ValidQuerySingleTag             = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"
+	ValidExpectedRequestDoubleTag   = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag-1\ntest-tag-2\n}}}}}}}"}`
+	ValidQueryDoubleTag             = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag-1\ntest-tag-2\n}}}}}}}"
+	ValidExpectedRequestDoubleField = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field-1\ntest-field-2\ntest-tag\n}}}}}}}"}`
+	ValidQueryDoubleField           = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field-1\ntest-field-2\ntest-tag\n}}}}}}}"
+	InvalidRouterExpectedRequest    = `{"query":"query {allRouters(name:\"not-a-router\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"}`
+	InvalidRouterQuery              = "query {allRouters(name:\"not-a-router\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"
+	InvalidFieldExpectedRequest     = `{"query":"query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ninvalid-field\ntest-tag\n}}}}}}}"}`
+	InvalidFieldQuery               = "query {allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ninvalid-field\ntest-tag\n}}}}}}}"
 )
 
 //TODO: more unit tests - MON-314
@@ -60,9 +60,9 @@ var ResponseProcessingTestCases = []struct {
 		Name:            "empty response produces error",
 		EntryPoint:      "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
 		Fields:          map[string]string{"test-field": "test-field"},
-		Tags:            map[string]string{},
-		Query:           ValidQueryNoTag,
-		Endpoint:        Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestNoTag, "{}"},
+		Tags:            map[string]string{"test-tag": "test-tag"},
+		Query:           ValidQuerySingleTag,
+		Endpoint:        Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestSingleTag, "{}"},
 		ExpectedMetrics: nil,
 		ExpectedErrors: []string{
 			"unexpected response for collector test-collector: {}",
@@ -72,9 +72,9 @@ var ResponseProcessingTestCases = []struct {
 		Name:       "none value produces error",
 		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
 		Fields:     map[string]string{"test-field": "test-field"},
-		Tags:       map[string]string{},
-		Query:      ValidQueryNoTag,
-		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestNoTag, `{
+		Tags:       map[string]string{"test-tag": "test-tag"},
+		Query:      ValidQuerySingleTag,
+		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestSingleTag, `{
 			"data": {
 				"allRouters": {
 				  	"nodes": [{
@@ -82,7 +82,8 @@ var ResponseProcessingTestCases = []struct {
 							"nodes": [{
 								"arp": {
 							  		"nodes": [{
-								  		"test-field": null
+								  		"test-field": null,
+										"test-tag": "test-string"
 									}]
 								}
 						  	}]
@@ -133,9 +134,9 @@ var ResponseProcessingTestCases = []struct {
 		Name:       "uses multiple fields",
 		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
 		Fields:     map[string]string{"test-field-1": "test-field-1", "test-field-2": "test-field-2"},
-		Tags:       map[string]string{},
-		Query:      ValidQueryDoubleTag,
-		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestDoubleTag, `{
+		Tags:       map[string]string{"test-tag": "test-tag"},
+		Query:      ValidQueryDoubleField,
+		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestDoubleField, `{
 			"data": {
 				"allRouters": {
 				  	"nodes": [{
@@ -144,7 +145,8 @@ var ResponseProcessingTestCases = []struct {
 								"arp": {
 							  		"nodes": [{
 								  		"test-field-1": 128,
-										"test-field-2": 95
+										"test-field-2": 95,
+										"test-tag": "test-string"
 									}]
 								}
 						  	}]
@@ -156,7 +158,7 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedMetrics: []*testutil.Metric{
 			{
 				Measurement: "test-collector",
-				Tags:        map[string]string{},
+				Tags:        map[string]string{"test-tag": "test-string"},
 				Fields:      map[string]interface{}{"test-field-1": 128.0, "test-field-2": 95.0},
 			},
 		},
@@ -309,7 +311,7 @@ var ResponseProcessingTestCases = []struct {
 		Name:            "propogates not found error to accumulator",
 		EntryPoint:      "allRouters[name:not-a-router]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
 		Fields:          map[string]string{"test-field": "test-field"},
-		Tags:            map[string]string{},
+		Tags:            map[string]string{"test-tag": "test-tag"},
 		Query:           InvalidRouterQuery,
 		Endpoint:        Endpoint{"/api/v1/graphql/", 404, InvalidRouterExpectedRequest, `it's not right`},
 		ExpectedMetrics: nil,
@@ -321,9 +323,9 @@ var ResponseProcessingTestCases = []struct {
 		Name:            "propogates invalid json error to accumulator",
 		EntryPoint:      "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
 		Fields:          map[string]string{"test-field": "test-field"},
-		Tags:            map[string]string{},
-		Query:           ValidQueryNoTag,
-		Endpoint:        Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestNoTag, `{"test": }`},
+		Tags:            map[string]string{"test-tag": "test-tag"},
+		Query:           ValidQuerySingleTag,
+		Endpoint:        Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestSingleTag, `{"test": }`},
 		ExpectedMetrics: nil,
 		ExpectedErrors:  []string{"invalid json response for collector test-collector: invalid character '}' looking for beginning of value"},
 	},
@@ -331,7 +333,7 @@ var ResponseProcessingTestCases = []struct {
 		Name:       "propogates graphQL error to accumulator",
 		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
 		Fields:     map[string]string{"invalid-field": "invalid-field"},
-		Tags:       map[string]string{},
+		Tags:       map[string]string{"test-tag": "test-tag"},
 		Query:      InvalidFieldQuery,
 		Endpoint: Endpoint{"/api/v1/graphql/", 200, InvalidFieldExpectedRequest, `
 		{
@@ -356,13 +358,6 @@ var QueryFormationTestCases = []struct {
 	Tags          map[string]string
 	ExpectedQuery string
 }{
-	{
-		Name:          "convert simple query no tag",
-		EntryPoint:    "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
-		Fields:        map[string]string{"test-field": "test-field"},
-		Tags:          map[string]string{},
-		ExpectedQuery: ValidQueryNoTag,
-	},
 	{
 		Name:          "convert simple query single tag",
 		EntryPoint:    "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -1,0 +1,442 @@
+package t128_graphql_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	plugin "github.com/influxdata/telegraf/plugins/inputs/t128_graphql"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type Endpoint struct {
+	URL             string
+	Code            int
+	ExpectedRequest string
+	Response        string
+}
+
+const (
+	ValidExpectedRequestNoTag     = `{"query":"query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"}`
+	ValidQueryNoTag               = "query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"
+	ValidExpectedRequestSingleTag = `{"query":"query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"}`
+	ValidQuerySingleTag           = "query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag\n}}}}}}}"
+	ValidExpectedRequestDoubleTag = `{"query":"query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag-1\ntest-tag-2\n}}}}}}}"}`
+	ValidQueryDoubleTag           = "query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\ntest-tag-1\ntest-tag-2\n}}}}}}}"
+	InvalidRouterExpectedRequest  = `{"query":"query MyQuery{allRouters(name:\"not-a-router\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"}`
+	InvalidRouterQuery            = "query MyQuery{allRouters(name:\"not-a-router\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ntest-field\n}}}}}}}"
+	InvalidFieldExpectedRequest   = `{"query":"query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ninvalid-field\n}}}}}}}"}`
+	InvalidFieldQuery             = "query MyQuery{allRouters(name:\"ComboEast\"){nodes{nodes(name:\"east-combo\"){nodes{arp{nodes{\ninvalid-field\n}}}}}}}"
+)
+
+var ResponseProcessingTestCases = []struct {
+	Name            string
+	EntryPoint      string
+	Fields          map[string]string
+	Tags            map[string]string
+	Query           string
+	Endpoint        Endpoint
+	ExpectedMetrics []*testutil.Metric
+	ExpectedErrors  []string
+}{
+	{
+		Name:       "empty query produces error",
+		EntryPoint: "",
+		Fields:     nil,
+		Tags:       nil,
+		Query:      "query MyQuery{{\n}}",
+		Endpoint: Endpoint{"/api/v1/graphql", 400, `{"query":"query MyQuery{{\n}}"}`, `
+		{
+			"errors": [{
+				"name": "BadRequestError",
+				"message": "Must provide query string."
+			}]
+		}
+		`},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"status code 400 not OK for metric test-metric: Must provide query string.",
+		},
+	},
+	{
+		Name:            "empty response produces error",
+		EntryPoint:      "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:          map[string]string{"test-field": "test-field"},
+		Tags:            map[string]string{},
+		Query:           ValidQueryNoTag,
+		Endpoint:        Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestNoTag, "{}"},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"unexpected response for metric test-metric: {}",
+		},
+	},
+	{
+		Name:       "none value produces error",
+		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field": "test-field"},
+		Tags:       map[string]string{},
+		Query:      ValidQueryNoTag,
+		Endpoint: Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestNoTag, `{
+			"data": {
+				"allRouters": {
+				  	"nodes": [{
+					  	"nodes": {
+							"nodes": [{
+								"arp": {
+							  		"nodes": [{
+								  		"test-field": null
+									}]
+								}
+						  	}]
+					  	}
+					}]
+				}
+			}
+		}`},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"found empty data for metric test-metric: field test-field",
+		},
+	},
+	{
+		Name:       "converts tag to string if numeric",
+		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field": "test-field"},
+		Tags:       map[string]string{"test-tag": "test-tag"},
+		Query:      ValidQuerySingleTag,
+		Endpoint: Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestSingleTag, `{
+			"data": {
+				"allRouters": {
+				  	"nodes": [{
+					  	"nodes": {
+							"nodes": [{
+								"arp": {
+							  		"nodes": [{
+								  		"test-field": 128,
+								  		"test-tag": 128
+									}]
+								}
+						  	}]
+					  	}
+					}]
+				}
+			}
+		}`},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"test-tag": "128"},
+				Fields:      map[string]interface{}{"test-field": 128.0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:       "uses multiple tags",
+		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field": "test-field"},
+		Tags:       map[string]string{"test-tag-1": "test-tag-1", "test-tag-2": "test-tag-2"},
+		Query:      ValidQueryDoubleTag,
+		Endpoint: Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestDoubleTag, `{
+			"data": {
+				"allRouters": {
+				  	"nodes": [{
+					  	"nodes": {
+							"nodes": [{
+								"arp": {
+							  		"nodes": [{
+								  		"test-field": 128,
+										"test-tag-1": "test-string-1",
+										"test-tag-2": "test-string-2"
+									}]
+								}
+						  	}]
+					  	}
+					}]
+				}
+			}
+		}`},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"test-tag-1": "test-string-1", "test-tag-2": "test-string-2"},
+				Fields:      map[string]interface{}{"test-field": 128.0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:       "uses multiple tags with some none value",
+		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field": "test-field"},
+		Tags:       map[string]string{"test-tag-1": "test-tag-1", "test-tag-2": "test-tag-2"},
+		Query:      ValidQueryDoubleTag,
+		Endpoint: Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestDoubleTag, `{
+			"data": {
+				"allRouters": {
+				  	"nodes": [{
+					  	"nodes": {
+							"nodes": [{
+								"arp": {
+							  		"nodes": [{
+								  		"test-field": 128,
+										"test-tag-1": "test-string-1",
+										"test-tag-2": null
+									}]
+								}
+						  	}]
+					  	}
+					}]
+				}
+			}
+		}`},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"test-tag-1": "test-string-1", "test-tag-2": "test-tag-2"},
+				Fields:      map[string]interface{}{"test-field": 128.0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:       "renames tags and fields",
+		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field-renamed": "test-field"},
+		Tags:       map[string]string{"test-tag-renamed": "test-tag"},
+		Query:      ValidQuerySingleTag,
+		Endpoint: Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestSingleTag, `{
+			"data": {
+				"allRouters": {
+				  	"nodes": [{
+					  	"nodes": {
+							"nodes": [{
+								"arp": {
+							  		"nodes": [{
+								  		"test-field": 128,
+								  		"test-tag": "test-string"
+									}]
+								}
+						  	}]
+					  	}
+					}]
+				}
+			}
+		}`},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"test-tag-renamed": "test-string"},
+				Fields:      map[string]interface{}{"test-field-renamed": 128.0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:       "processes response with multiple nodes",
+		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field": "test-field"},
+		Tags:       map[string]string{"test-tag": "test-tag"},
+		Query:      ValidQuerySingleTag,
+		Endpoint: Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestSingleTag, `{
+			"data": {
+				"allRouters": {
+				  	"nodes": [{
+					  	"nodes": {
+							"nodes": [{
+								"arp": {
+							  		"nodes": [{
+								  		"test-field": 128,
+								  		"test-tag": "test-string-1"
+									},
+									{
+										"test-field": 95,
+										"test-tag": "test-string-2"
+								  	}]
+								}
+						  	}]
+					  	}
+					}]
+				}
+			}
+		}`},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"test-tag": "test-string-1"},
+				Fields:      map[string]interface{}{"test-field": 128.0},
+			},
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{"test-tag": "test-string-2"},
+				Fields:      map[string]interface{}{"test-field": 95.0},
+			},
+		},
+		ExpectedErrors: nil,
+	},
+	{
+		Name:            "propogates not found error to accumulator",
+		EntryPoint:      "allRouters[name:not-a-router]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:          map[string]string{"test-field": "test-field"},
+		Tags:            map[string]string{},
+		Query:           InvalidRouterQuery,
+		Endpoint:        Endpoint{"/api/v1/graphql", 404, InvalidRouterExpectedRequest, `it's not right`},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"status code 404 not OK for metric test-metric: it's not right",
+		},
+	},
+	{
+		Name:            "propogates invalid json error to accumulator",
+		EntryPoint:      "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:          map[string]string{"test-field": "test-field"},
+		Tags:            map[string]string{},
+		Query:           ValidQueryNoTag,
+		Endpoint:        Endpoint{"/api/v1/graphql", 200, ValidExpectedRequestNoTag, `{"test": }`},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  []string{"invalid json response for metric test-metric: invalid character '}' looking for beginning of value"},
+	},
+	{
+		Name:       "propogates graphQL error to accumulator",
+		EntryPoint: "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:     map[string]string{"invalid-field": "invalid-field"},
+		Tags:       map[string]string{},
+		Query:      InvalidFieldQuery,
+		Endpoint: Endpoint{"/api/v1/graphql", 200, InvalidFieldExpectedRequest, `
+		{
+			"errors": [{
+				"name": "GraphQLError",
+				"message": "Cannot query field \"invalid-field\" on type \"ArpEntryType\".",
+				"locations": [{
+					"line": 2,
+					"column": 1
+				}]
+			}]
+		  }`},
+		ExpectedMetrics: nil,
+		ExpectedErrors:  []string{"unexpected response for metric test-metric: Cannot query field \"invalid-field\" on type \"ArpEntryType\"."},
+	},
+}
+
+var QueryFormationTestCases = []struct {
+	Name          string
+	EntryPoint    string
+	Fields        map[string]string
+	Tags          map[string]string
+	ExpectedQuery string
+}{
+	{
+		Name:          "convert simple query no tag",
+		EntryPoint:    "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:        map[string]string{"test-field": "test-field"},
+		Tags:          map[string]string{},
+		ExpectedQuery: ValidQueryNoTag,
+	},
+	{
+		Name:          "convert simple query single tag",
+		EntryPoint:    "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:        map[string]string{"test-field": "test-field"},
+		Tags:          map[string]string{"test-tag": "test-tag"},
+		ExpectedQuery: ValidQuerySingleTag,
+	},
+	{
+		Name:          "convert simple query double tag",
+		EntryPoint:    "allRouters[name:ComboEast]/nodes/nodes[name:east-combo]/nodes/arp/nodes",
+		Fields:        map[string]string{"test-field": "test-field"},
+		Tags:          map[string]string{"test-tag-1": "test-tag-1", "test-tag-2": "test-tag-2"},
+		ExpectedQuery: ValidQueryDoubleTag,
+	},
+}
+
+func TestT128GraphqlResponseProcessing(t *testing.T) {
+	for _, testCase := range ResponseProcessingTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			fakeServer := createTestServer(t, testCase.Endpoint)
+			defer fakeServer.Close()
+
+			plugin := &plugin.T128GraphQL{
+				CollectorName: "test-metric",
+				BaseURL:       fakeServer.URL,
+				EntryPoint:    testCase.EntryPoint,
+				Fields:        testCase.Fields,
+				Tags:          testCase.Tags,
+			}
+
+			var acc testutil.Accumulator
+			require.NoError(t, plugin.Init())
+			plugin.Query = testCase.Query
+			plugin.Gather(&acc)
+
+			var errorStrings []string = nil
+			for _, err := range acc.Errors {
+				errorStrings = append(errorStrings, err.Error())
+			}
+
+			require.ElementsMatch(t, testCase.ExpectedErrors, errorStrings)
+
+			// Timestamps aren't important, but need to match
+			for _, m := range acc.Metrics {
+				m.Time = time.Time{}
+			}
+
+			// Avoid specifying this unused type for each field
+			for _, m := range testCase.ExpectedMetrics {
+				m.Type = telegraf.Untyped
+			}
+
+			require.ElementsMatch(t, testCase.ExpectedMetrics, acc.Metrics)
+		})
+	}
+}
+
+func TestT128GraphqlQueryFormation(t *testing.T) {
+	for _, testCase := range QueryFormationTestCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			plugin := &plugin.T128GraphQL{
+				CollectorName: "test-metric",
+				BaseURL:       "/api/v1/graphql",
+				EntryPoint:    testCase.EntryPoint,
+				Fields:        testCase.Fields,
+				Tags:          testCase.Tags,
+			}
+
+			require.NoError(t, plugin.Init())
+			require.Equal(t, testCase.ExpectedQuery, plugin.Query)
+		})
+	}
+}
+
+func createTestServer(t *testing.T, endpoint Endpoint) *httptest.Server {
+	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.Equal(t, "POST", r.Method)
+
+		if endpoint.URL != r.URL.Path {
+			fmt.Printf("There isn't an endpoint for: %v\n", r.URL.Path)
+			w.WriteHeader(404)
+			return
+		}
+
+		if endpoint.ExpectedRequest != "" {
+			contents, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				w.WriteHeader(500)
+				return
+			}
+
+			require.JSONEq(t, endpoint.ExpectedRequest, string(contents), "Unexpected request body for endpoint %s", endpoint.URL)
+		}
+
+		w.WriteHeader(endpoint.Code)
+		w.Write([]byte(endpoint.Response))
+	}))
+
+	return fakeServer
+}


### PR DESCRIPTION
# Description

graphql collector is a general-purpose collector that uses graphql queries on 128T nodes to create telegraf metrics. To fully replace existing graphql-based collectors (such as t128_arp_state) there will be additional changes on the 128T-monitoring-agent.

# Testing

Unit tests and with `monitoring-agent-cli test-input`.

Output from t128_arp_state
```
[centos@t190-dut2 ~]$ sudo cat /etc/128t-monitoring/config.yaml
enabled: true
lib-directory: /var/lib/128t-monitoring
sample-interval: 5
push-interval: 10
inputs:
  - name: t128_arp_state
    include-outputs: [file]
outputs:
  - name: file
[centos@t190-dut2 ~]$ sudo monitoring-agent-cli configure
The command will restart existing 128T-telegraf service instances. Do you want to continue? [Y/n]: Y
Stopping telegraf service 128T-telegraf@t128_arp_state.service
Stopping telegraf service 128T-telegraf@t128_graphql.service
Started telegraf service 128T-telegraf@t128_arp_state.service for t128_arp_state
[centos@t190-dut2 ~]$ sudo monitoring-agent-cli test-input t128_arp_state
Testing input t128_arp_state
2021-02-04T15:25:21Z I! Starting Telegraf
2021-02-04T15:25:21Z D! [agent] Initializing plugins
2021-02-04T15:25:21Z D! [agent] Starting service inputs
> arp-state,destination-mac=fa:16:3e:62:52:31,device-interface=12,host=t190-dut2.openstacklocal,ip-address=172.16.3.5,network-interface=intf12,vlan=0 state="Valid" 1612452322000000000
> arp-state,destination-mac=ee:d9:44:7e:fc:69,device-interface=client1,host=t190-dut2.openstacklocal,ip-address=169.254.129.2,network-interface=client1-intf,vlan=0 state="Valid" 1612452322000000000
> arp-state,destination-mac=66:2c:43:71:e3:f9,device-interface=rem2,host=t190-dut2.openstacklocal,ip-address=169.254.129.6,network-interface=rem2-intf,vlan=0 state="Valid" 1612452322000000000
2021-02-04T15:26:22Z D! [agent] Stopping service inputs
2021-02-04T15:26:22Z D! [agent] Input channel closed
2021-02-04T15:26:22Z D! [agent] Stopped Successfully
```

Output from t128_graphql configured to replace t128_arp_state. 
```
[centos@t190-dut2 ~]$ sudo cat /etc/128t-monitoring/config.yaml
enabled: true
lib-directory: /var/lib/128t-monitoring
sample-interval: 5
push-interval: 10
inputs:
  - name: t128_graphql
    include-outputs: [file]
outputs:
  - name: file
[centos@t190-dut2 ~]$ sudo monitoring-agent-cli configure
The command will restart existing 128T-telegraf service instances. Do you want to continue? [Y/n]: Y
Stopping telegraf service 128T-telegraf@t128_arp_state.service
Stopping telegraf service 128T-telegraf@t128_graphql.service
Started telegraf service 128T-telegraf@t128_graphql.service for t128_graphql
[centos@t190-dut2 ~]$ sudo monitoring-agent-cli test-input t128_graphql
Testing input t128_graphql
2021-02-04T16:46:54Z I! Starting Telegraf
2021-02-04T16:46:54Z D! [agent] Initializing plugins
2021-02-04T16:46:54Z D! [agent] Starting service inputs
> arp-state,destination-mac=fa:16:3e:62:52:31,device-interface=12,host=t190-dut2.openstacklocal,ip-address=172.16.3.5,network-interface=intf12,vlan=0 state="Valid" 1612457214000000000
> arp-state,destination-mac=ee:d9:44:7e:fc:69,device-interface=client1,host=t190-dut2.openstacklocal,ip-address=169.254.129.2,network-interface=client1-intf,vlan=0 state="Valid" 1612457214000000000
> arp-state,destination-mac=66:2c:43:71:e3:f9,device-interface=rem2,host=t190-dut2.openstacklocal,ip-address=169.254.129.6,network-interface=rem2-intf,vlan=0 state="Valid" 1612457214000000000
2021-02-04T16:47:54Z D! [agent] Stopping service inputs
2021-02-04T16:47:54Z D! [agent] Input channel closed
2021-02-04T16:47:54Z D! [agent] Stopped Successfully
```

MON-307 #time 5d

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.
