### PR TITLE
Allow tagless t128graphql config

### DIFF
--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -109,10 +109,6 @@ func (plugin *T128GraphQL) checkConfig() error {
 		return fmt.Errorf("extract_fields is a required configuration field")
 	}
 
-	if plugin.Tags == nil {
-		return fmt.Errorf("extract_tags is a required configuration field")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
# Description
The t128graphql collector currently requires tags to be configured. This changes removes that requirement to provide more flexibility for the user.

# Testing
Unit tests
