### PR TITLE
Sort the request IDs during construction for consistent ID ordering

### DIFF
--- a/plugins/inputs/t128_metrics/retriever.go
+++ b/plugins/inputs/t128_metrics/retriever.go
@@ -61,6 +61,8 @@ func NewBulkRetriever(useIntegerConversion bool, configuredMetrics []ConfiguredM
 			bulkRequest.OutFields[requestID] = fieldName
 		}
 
+		sort.Strings(bulkRequest.IDs)
+
 		var err error
 		bulkRequest.RequestBody, err = json.Marshal(bulkRequest)
 		if err != nil {

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -509,7 +509,7 @@ var ResponseProcessingTestCases = []struct {
 			},
 			map[string][]string{},
 		}},
-		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/test", "/stats/another/test"]}`, `[{
+		Endpoints: []Endpoint{{"/", 200, `{"ids": ["/stats/another/test", "/stats/test"]}`, `[{
 				"id": "/stats/test",
 				"permutations": [{
 					"parameters": [],


### PR DESCRIPTION
## Description

Because the request ID's come from the fields map, their ordering is not consistent. The result is some flaky tests. I've added a simple sort of the IDs so they can be deterministically tested. This is only run once during start-up, so there won't be any performance impact.
