### PR TITLE
Create a state-change transform type for the t128_transform processor

### DIFF
--- a/plugins/processors/t128_transform/t128_transform_state_change_test.go
+++ b/plugins/processors/t128_transform/t128_transform_state_change_test.go
@@ -1,0 +1,255 @@
+package t128_transform
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStateChangeSendFirstSample(t *testing.T) {
+	r := newTransformType("state-change")
+	r.Fields = map[string]string{"/my/state": "/my/state"}
+	assert.Nil(t, r.Init())
+
+	m := newMetric("foo", nil, map[string]interface{}{"/my/state": "state1"}, time.Now())
+
+	rate := r.Apply(m)
+	assert.Len(t, rate, 1)
+	assert.Equal(t, rate[0].Fields()["/my/state"], "state1")
+}
+
+func TestStateChangeSendsOnExpired(t *testing.T) {
+	r := newTransformType("state-change")
+	r.Fields = map[string]string{"/my/state": "/my/state"}
+	r.Expiration.Duration = 10 * time.Second
+	assert.Nil(t, r.Init())
+
+	t1 := time.Now()
+	t2 := t1.Add(10 * time.Second)
+	t3 := t2.Add(10*time.Second + 1*time.Nanosecond)
+
+	m1 := newMetric("foo", nil, map[string]interface{}{"/my/state": "state1"}, t1)
+	m2 := newMetric("foo", nil, map[string]interface{}{"/my/state": "state1"}, t2)
+	m3 := newMetric("foo", nil, map[string]interface{}{"/my/state": "state1"}, t3)
+
+	r.Apply(m1)
+	assert.Len(t, r.Apply(m2)[0].FieldList(), 0)
+	assert.Len(t, r.Apply(m3)[0].FieldList(), 1)
+}
+
+func TestStateChangeLeavesUnmarkedFieldsInTact(t *testing.T) {
+	r := newTransformType("state-change")
+	r.Fields = map[string]string{"/my/state": "/my/state"}
+	assert.Nil(t, r.Init())
+
+	t1 := time.Now()
+	t2 := t1.Add(time.Second * 1)
+
+	m1 := newMetric("foo", nil, map[string]interface{}{"/my/state": 50, "/unmarked": 50}, t1)
+	m2 := newMetric("foo", nil, map[string]interface{}{"/my/state": 60, "/unmarked": 60}, t2)
+
+	outputs := r.Apply(m1)
+	assert.Len(t, outputs, 1)
+	assert.Len(t, outputs[0].FieldList(), 2)
+
+	v, ok := outputs[0].GetField("/my/state")
+	assert.True(t, ok)
+	assert.Equal(t, int64(50), v)
+
+	v, ok = outputs[0].GetField("/unmarked")
+	assert.True(t, ok)
+	assert.Equal(t, int64(50), v)
+
+	outputs = r.Apply(m2)
+	assert.Len(t, outputs, 1)
+
+	v, ok = outputs[0].GetField("/my/state")
+	assert.True(t, ok)
+	assert.Equal(t, int64(60), v)
+
+	v, ok = outputs[0].GetField("/unmarked")
+	assert.True(t, ok)
+	assert.Equal(t, int64(60), v)
+}
+
+func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
+	testCases := []struct {
+		Name            string
+		Fields          map[string]string
+		LastSample      map[string]interface{}
+		CurrentSample   map[string]interface{}
+		TimeDelta       time.Duration
+		RemoveOriginal  bool
+		RemainingFields []string
+	}{
+		{
+			Name:            "remove-matching-new",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{},
+			CurrentSample:   map[string]interface{}{"/state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "remove-matching-existing-same",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{"/state": 45},
+			CurrentSample:   map[string]interface{}{"/state": 45},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{},
+		},
+		{
+			Name:            "remove-matching-existing-changed",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{"/state": 45},
+			CurrentSample:   map[string]interface{}{"/state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "remove-matching-expired",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{"/state": 45},
+			CurrentSample:   map[string]interface{}{"/state": 50},
+			TimeDelta:       6 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "remove-mismatching-new",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{},
+			CurrentSample:   map[string]interface{}{"/non-state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "remove-mismatching-existing-same",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{"/non-state": 45},
+			CurrentSample:   map[string]interface{}{"/non-state": 45},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{},
+		},
+		{
+			Name:            "remove-mismatching-existing-changed",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{"/non-state": 45},
+			CurrentSample:   map[string]interface{}{"/non-state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "remove-mismatching-expired",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{"/non-state": 45},
+			CurrentSample:   map[string]interface{}{"/non-state": 50},
+			TimeDelta:       6 * time.Second,
+			RemoveOriginal:  true,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "leave-matching-new",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{},
+			CurrentSample:   map[string]interface{}{"/state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "leave-matching-existing-same",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{"/state": 45},
+			CurrentSample:   map[string]interface{}{"/state": 45},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{},
+		},
+		{
+			Name:            "leave-matching-existing-changed",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{"/state": 45},
+			CurrentSample:   map[string]interface{}{"/state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "leave-matching-expired",
+			Fields:          map[string]string{"/state": "/state"},
+			LastSample:      map[string]interface{}{"/state": 45},
+			CurrentSample:   map[string]interface{}{"/state": 50},
+			TimeDelta:       6 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{"/state"},
+		},
+		{
+			Name:            "leave-mismatching-new",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{},
+			CurrentSample:   map[string]interface{}{"/non-state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{"/non-state", "/state"},
+		},
+		{
+			Name:            "leave-mismatching-existing-same",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{"/non-state": 45},
+			CurrentSample:   map[string]interface{}{"/non-state": 45},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{"/non-state"},
+		},
+		{
+			Name:            "leave-mismatching-existing-changed",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{"/non-state": 45},
+			CurrentSample:   map[string]interface{}{"/non-state": 50},
+			TimeDelta:       5 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{"/non-state", "/state"},
+		},
+		{
+			Name:            "leave-mismatching-expired",
+			Fields:          map[string]string{"/state": "/non-state"},
+			LastSample:      map[string]interface{}{"/non-state": 45},
+			CurrentSample:   map[string]interface{}{"/non-state": 50},
+			TimeDelta:       6 * time.Second,
+			RemoveOriginal:  false,
+			RemainingFields: []string{"/non-state", "/state"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			r := newTransformType("state-change")
+			r.Fields = testCase.Fields
+			r.RemoveOriginal = testCase.RemoveOriginal
+			r.Expiration.Duration = 5 * time.Second
+			assert.Nil(t, r.Init())
+
+			t1 := time.Now()
+			m1 := newMetric("foo", nil, testCase.LastSample, t1)
+			m2 := newMetric("foo", nil, testCase.CurrentSample, t1.Add(testCase.TimeDelta))
+
+			r.Apply(m1)
+			result := r.Apply(m2)[0]
+
+			assert.Len(t, result.FieldList(), len(testCase.RemainingFields))
+
+			for _, field := range testCase.RemainingFields {
+				_, exists := result.GetField(field)
+				assert.Truef(t, exists, "the field '%v' doesn't exist", field)
+			}
+		})
+	}
+}

--- a/plugins/processors/t128_transform/t128_transform_state_change_test.go
+++ b/plugins/processors/t128_transform/t128_transform_state_change_test.go
@@ -81,7 +81,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 		Fields         map[string]string
 		Samples        []sample
 		PreviousFields map[string]string
-		TimeDelta      time.Duration
+		Timestamps     []int
 		RemoveOriginal bool
 		Result         sample
 	}{
@@ -92,7 +92,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{},
 				{"/state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: true,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -103,7 +103,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": 45},
 				{"/state": 45},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: true,
 			Result:         sample{},
 		},
@@ -114,7 +114,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": 45},
 				{"/state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: true,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -125,7 +125,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": 45},
 				{"/state": 50},
 			},
-			TimeDelta:      6 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: true,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -136,7 +136,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{},
 				{"/non-state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: true,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -147,7 +147,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/non-state": 45},
 				{"/non-state": 45},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: true,
 			Result:         sample{},
 		},
@@ -158,7 +158,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/non-state": 45},
 				{"/non-state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: true,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -169,7 +169,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/non-state": 45},
 				{"/non-state": 50},
 			},
-			TimeDelta:      6 * time.Second,
+			Timestamps:     []int{0, 6},
 			RemoveOriginal: true,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -180,7 +180,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{},
 				{"/state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: false,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -191,7 +191,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": 45},
 				{"/state": 45},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: false,
 			Result:         sample{},
 		},
@@ -202,7 +202,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": 45},
 				{"/state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: false,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -213,7 +213,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": 45},
 				{"/state": 50},
 			},
-			TimeDelta:      6 * time.Second,
+			Timestamps:     []int{0, 6},
 			RemoveOriginal: false,
 			Result:         sample{"/state": int64(50)},
 		},
@@ -224,7 +224,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{},
 				{"/non-state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: false,
 			Result:         sample{"/non-state": int64(50), "/state": int64(50)},
 		},
@@ -235,7 +235,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/non-state": 45},
 				{"/non-state": 45},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: false,
 			Result:         sample{"/non-state": int64(45)},
 		},
@@ -246,7 +246,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/non-state": 45},
 				{"/non-state": 50},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
 			RemoveOriginal: false,
 			Result:         sample{"/non-state": int64(50), "/state": int64(50)},
 		},
@@ -257,7 +257,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/non-state": 45},
 				{"/non-state": 50},
 			},
-			TimeDelta:      6 * time.Second,
+			Timestamps:     []int{0, 6},
 			RemoveOriginal: false,
 			Result:         sample{"/non-state": int64(50), "/state": int64(50)},
 		},
@@ -269,7 +269,7 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 			Samples: []sample{
 				{"/state": "s1"},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0},
 			RemoveOriginal: true,
 			Result:         sample{"/state": "s1"},
 		},
@@ -281,7 +281,20 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": "s1"},
 				{"/state": "s2"},
 			},
-			TimeDelta:      5 * time.Second,
+			Timestamps:     []int{0, 5},
+			RemoveOriginal: true,
+			Result:         sample{"/state": "s2", "/previous": "s1"},
+		},
+		{
+			Name:           "previous-after-multiple-matching",
+			Fields:         map[string]string{"/state": "/state"},
+			PreviousFields: map[string]string{"/previous": "/state"},
+			Samples: []sample{
+				{"/state": "s1"},
+				{"/state": "s1"},
+				{"/state": "s2"},
+			},
+			Timestamps:     []int{0, 5, 10},
 			RemoveOriginal: true,
 			Result:         sample{"/state": "s2", "/previous": "s1"},
 		},
@@ -293,14 +306,35 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 				{"/state": "s1"},
 				{"/state": "s2"},
 			},
-			TimeDelta:      6 * time.Second,
+			Timestamps:     []int{0, 6},
 			RemoveOriginal: true,
 			Result:         sample{"/state": "s2", "/previous": "s1"},
+		},
+		{
+			Name:           "previous-after-expired",
+			Fields:         map[string]string{"/state": "/state"},
+			PreviousFields: map[string]string{"/previous": "/state"},
+			Samples: []sample{
+				{"/state": "s1"},
+				{"/state": "s2"},
+				{"/state": "s3"},
+			},
+			Timestamps:     []int{0, 6, 11},
+			RemoveOriginal: true,
+			Result:         sample{"/state": "s3", "/previous": "s2"},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
+			assert.True(t, len(testCase.Samples) > 0)
+
+			assert.Truef(t,
+				len(testCase.Samples) == len(testCase.Timestamps),
+				"The number of timestamps (%v) needs to equal the number of samples (%v)",
+				len(testCase.Timestamps),
+				len(testCase.Samples),
+			)
 			r := newTransformType("state-change")
 			r.Fields = testCase.Fields
 			r.PreviousFields = testCase.PreviousFields
@@ -309,14 +343,14 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 			assert.Nil(t, r.Init())
 
 			t1 := time.Now()
-			for i := 0; i < len(testCase.Samples)-1; i++ {
-				timestamp := t1.Add(time.Duration(i) * testCase.TimeDelta)
-				r.Apply(newMetric("foo", nil, testCase.Samples[i], timestamp))
+			sampleIndex := 0
+			for sampleIndex = 0; sampleIndex < len(testCase.Samples)-1; sampleIndex++ {
+				r.Apply(newMetric("foo", nil, testCase.Samples[sampleIndex], t1.Add(time.Duration(testCase.Timestamps[sampleIndex])*time.Second)))
 			}
 
 			m := newMetric("foo", nil,
-				testCase.Samples[len(testCase.Samples)-1],
-				t1.Add(testCase.TimeDelta*time.Duration(len(testCase.Samples)-1)),
+				testCase.Samples[sampleIndex],
+				t1.Add(time.Duration(testCase.Timestamps[sampleIndex])*time.Second),
 			)
 
 			result := r.Apply(m)[0]

--- a/plugins/processors/t128_transform/t128_transform_state_change_test.go
+++ b/plugins/processors/t128_transform/t128_transform_state_change_test.go
@@ -74,158 +74,228 @@ func TestStateChangeLeavesUnmarkedFieldsInTact(t *testing.T) {
 }
 
 func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
+	type sample = map[string]interface{}
+
 	testCases := []struct {
-		Name            string
-		Fields          map[string]string
-		LastSample      map[string]interface{}
-		CurrentSample   map[string]interface{}
-		TimeDelta       time.Duration
-		RemoveOriginal  bool
-		RemainingFields []string
+		Name           string
+		Fields         map[string]string
+		Samples        []sample
+		PreviousFields map[string]string
+		TimeDelta      time.Duration
+		RemoveOriginal bool
+		Result         sample
 	}{
 		{
-			Name:            "remove-matching-new",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/state"},
+			Name:   "remove-matching-new",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{},
+				{"/state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "remove-matching-existing-same",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{"/state": 45},
-			CurrentSample:   map[string]interface{}{"/state": 45},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{},
+			Name:   "remove-matching-existing-same",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{"/state": 45},
+				{"/state": 45},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
 		},
 		{
-			Name:            "remove-matching-existing-changed",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{"/state": 45},
-			CurrentSample:   map[string]interface{}{"/state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/state"},
+			Name:   "remove-matching-existing-changed",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{"/state": 45},
+				{"/state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "remove-matching-expired",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{"/state": 45},
-			CurrentSample:   map[string]interface{}{"/state": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/state"},
+			Name:   "remove-matching-expired",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{"/state": 45},
+				{"/state": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "remove-mismatching-new",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/non-state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/state"},
+			Name:   "remove-mismatching-new",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{},
+				{"/non-state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "remove-mismatching-existing-same",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{"/non-state": 45},
-			CurrentSample:   map[string]interface{}{"/non-state": 45},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{},
+			Name:   "remove-mismatching-existing-same",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{"/non-state": 45},
+				{"/non-state": 45},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
 		},
 		{
-			Name:            "remove-mismatching-existing-changed",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{"/non-state": 45},
-			CurrentSample:   map[string]interface{}{"/non-state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/state"},
+			Name:   "remove-mismatching-existing-changed",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{"/non-state": 45},
+				{"/non-state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "remove-mismatching-expired",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{"/non-state": 45},
-			CurrentSample:   map[string]interface{}{"/non-state": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/state"},
+			Name:   "remove-mismatching-expired",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{"/non-state": 45},
+				{"/non-state": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "leave-matching-new",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/state"},
+			Name:   "leave-matching-new",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{},
+				{"/state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "leave-matching-existing-same",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{"/state": 45},
-			CurrentSample:   map[string]interface{}{"/state": 45},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{},
+			Name:   "leave-matching-existing-same",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{"/state": 45},
+				{"/state": 45},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{},
 		},
 		{
-			Name:            "leave-matching-existing-changed",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{"/state": 45},
-			CurrentSample:   map[string]interface{}{"/state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/state"},
+			Name:   "leave-matching-existing-changed",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{"/state": 45},
+				{"/state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "leave-matching-expired",
-			Fields:          map[string]string{"/state": "/state"},
-			LastSample:      map[string]interface{}{"/state": 45},
-			CurrentSample:   map[string]interface{}{"/state": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/state"},
+			Name:   "leave-matching-expired",
+			Fields: map[string]string{"/state": "/state"},
+			Samples: []sample{
+				{"/state": 45},
+				{"/state": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/state": int64(50)},
 		},
 		{
-			Name:            "leave-mismatching-new",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/non-state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/non-state", "/state"},
+			Name:   "leave-mismatching-new",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{},
+				{"/non-state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/non-state": int64(50), "/state": int64(50)},
 		},
 		{
-			Name:            "leave-mismatching-existing-same",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{"/non-state": 45},
-			CurrentSample:   map[string]interface{}{"/non-state": 45},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/non-state"},
+			Name:   "leave-mismatching-existing-same",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{"/non-state": 45},
+				{"/non-state": 45},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/non-state": int64(45)},
 		},
 		{
-			Name:            "leave-mismatching-existing-changed",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{"/non-state": 45},
-			CurrentSample:   map[string]interface{}{"/non-state": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/non-state", "/state"},
+			Name:   "leave-mismatching-existing-changed",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{"/non-state": 45},
+				{"/non-state": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/non-state": int64(50), "/state": int64(50)},
 		},
 		{
-			Name:            "leave-mismatching-expired",
-			Fields:          map[string]string{"/state": "/non-state"},
-			LastSample:      map[string]interface{}{"/non-state": 45},
-			CurrentSample:   map[string]interface{}{"/non-state": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/non-state", "/state"},
+			Name:   "leave-mismatching-expired",
+			Fields: map[string]string{"/state": "/non-state"},
+			Samples: []sample{
+				{"/non-state": 45},
+				{"/non-state": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/non-state": int64(50), "/state": int64(50)},
+		},
+
+		{
+			Name:           "previous-new",
+			Fields:         map[string]string{"/state": "/state"},
+			PreviousFields: map[string]string{"/previous": "/state"},
+			Samples: []sample{
+				{"/state": "s1"},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": "s1"},
+		},
+		{
+			Name:           "previous-with-previous-value",
+			Fields:         map[string]string{"/state": "/state"},
+			PreviousFields: map[string]string{"/previous": "/state"},
+			Samples: []sample{
+				{"/state": "s1"},
+				{"/state": "s2"},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": "s2", "/previous": "s1"},
+		},
+		{
+			Name:           "previous-matching-expired",
+			Fields:         map[string]string{"/state": "/state"},
+			PreviousFields: map[string]string{"/previous": "/state"},
+			Samples: []sample{
+				{"/state": "s1"},
+				{"/state": "s2"},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/state": "s2", "/previous": "s1"},
 		},
 	}
 
@@ -233,23 +303,25 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 		t.Run(testCase.Name, func(t *testing.T) {
 			r := newTransformType("state-change")
 			r.Fields = testCase.Fields
+			r.PreviousFields = testCase.PreviousFields
 			r.RemoveOriginal = testCase.RemoveOriginal
 			r.Expiration.Duration = 5 * time.Second
 			assert.Nil(t, r.Init())
 
 			t1 := time.Now()
-			m1 := newMetric("foo", nil, testCase.LastSample, t1)
-			m2 := newMetric("foo", nil, testCase.CurrentSample, t1.Add(testCase.TimeDelta))
-
-			r.Apply(m1)
-			result := r.Apply(m2)[0]
-
-			assert.Len(t, result.FieldList(), len(testCase.RemainingFields))
-
-			for _, field := range testCase.RemainingFields {
-				_, exists := result.GetField(field)
-				assert.Truef(t, exists, "the field '%v' doesn't exist", field)
+			for i := 0; i < len(testCase.Samples)-1; i++ {
+				timestamp := t1.Add(time.Duration(i) * testCase.TimeDelta)
+				r.Apply(newMetric("foo", nil, testCase.Samples[i], timestamp))
 			}
+
+			m := newMetric("foo", nil,
+				testCase.Samples[len(testCase.Samples)-1],
+				t1.Add(testCase.TimeDelta*time.Duration(len(testCase.Samples)-1)),
+			)
+
+			result := r.Apply(m)[0]
+
+			assert.Equal(t, result.Fields(), testCase.Result)
 		})
 	}
 }

--- a/plugins/processors/t128_transform/t128_transform_test.go
+++ b/plugins/processors/t128_transform/t128_transform_test.go
@@ -165,147 +165,228 @@ func TestLeavesUnmarkedFieldsInTact(t *testing.T) {
 }
 
 func TestRemoveOriginalAndRename(t *testing.T) {
+	type sample = map[string]interface{}
+
 	testCases := []struct {
-		Name            string
-		Fields          map[string]string
-		LastSample      map[string]interface{}
-		CurrentSample   map[string]interface{}
-		TimeDelta       time.Duration
-		RemoveOriginal  bool
-		RemainingFields []string
+		Name           string
+		Fields         map[string]string
+		Samples        []sample
+		PreviousFields map[string]string
+		TimeDelta      time.Duration
+		RemoveOriginal bool
+		Result         sample
 	}{
 		{
-			Name:            "remove-matching-new",
-			Fields:          map[string]string{"/rate": "/rate"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{},
+			Name:   "remove-matching-new",
+			Fields: map[string]string{"/rate": "/rate"},
+			Samples: []sample{
+				{},
+				{"/rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
 		},
 		{
-			Name:            "remove-matching-existing",
-			Fields:          map[string]string{"/rate": "/rate"},
-			LastSample:      map[string]interface{}{"/rate": 45},
-			CurrentSample:   map[string]interface{}{"/rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/rate"},
+			Name:   "remove-matching-existing",
+			Fields: map[string]string{"/rate": "/rate"},
+			Samples: []sample{
+				{"/rate": 45},
+				{"/rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/rate": float64(1)},
 		},
 		{
-			Name:            "remove-matching-expired",
-			Fields:          map[string]string{"/rate": "/rate"},
-			LastSample:      map[string]interface{}{"/rate": 45},
-			CurrentSample:   map[string]interface{}{"/rate": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{},
+			Name:   "remove-matching-expired",
+			Fields: map[string]string{"/rate": "/rate"},
+			Samples: []sample{
+				{"/rate": 45},
+				{"/rate": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
 		},
 		{
-			Name:            "remove-mismatching-new",
-			Fields:          map[string]string{"/rate": "/non-rate"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/non-rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{},
+			Name:   "remove-mismatching-new",
+			Fields: map[string]string{"/rate": "/non-rate"},
+			Samples: []sample{
+				{},
+				{"/non-rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
 		},
 		{
-			Name:            "remove-mismatching-existing",
-			Fields:          map[string]string{"/rate": "/non-rate"},
-			LastSample:      map[string]interface{}{"/non-rate": 45},
-			CurrentSample:   map[string]interface{}{"/non-rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{"/rate"},
+			Name:   "remove-mismatching-existing",
+			Fields: map[string]string{"/rate": "/non-rate"},
+			Samples: []sample{
+				{"/non-rate": 45},
+				{"/non-rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/rate": float64(1)},
 		},
 		{
-			Name:            "remove-mismatching-expired",
-			Fields:          map[string]string{"/rate": "/non-rate"},
-			LastSample:      map[string]interface{}{"/non-rate": 45},
-			CurrentSample:   map[string]interface{}{"/non-rate": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  true,
-			RemainingFields: []string{},
+			Name:   "remove-mismatching-expired",
+			Fields: map[string]string{"/rate": "/non-rate"},
+			Samples: []sample{
+				{"/non-rate": 45},
+				{"/non-rate": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
 		},
 
 		{
-			Name:            "leave-matching-new",
-			Fields:          map[string]string{"/rate": "/rate"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{},
+			Name:   "leave-matching-new",
+			Fields: map[string]string{"/rate": "/rate"},
+			Samples: []sample{
+				{},
+				{"/rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{},
 		},
 		{
-			Name:            "leave-matching-existing",
-			Fields:          map[string]string{"/rate": "/rate"},
-			LastSample:      map[string]interface{}{"/rate": 45},
-			CurrentSample:   map[string]interface{}{"/rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/rate"},
+			Name:   "leave-matching-existing",
+			Fields: map[string]string{"/rate": "/rate"},
+			Samples: []sample{
+				{"/rate": 45},
+				{"/rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/rate": float64(1)},
 		},
 		{
-			Name:            "leave-matching-expired",
-			Fields:          map[string]string{"/rate": "/rate"},
-			LastSample:      map[string]interface{}{"/rate": 45},
-			CurrentSample:   map[string]interface{}{"/rate": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{},
+			Name:   "leave-matching-expired",
+			Fields: map[string]string{"/rate": "/rate"},
+			Samples: []sample{
+				{"/rate": 45},
+				{"/rate": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{},
 		},
 		{
-			Name:            "leave-mismatching-new",
-			Fields:          map[string]string{"/rate": "/non-rate"},
-			LastSample:      map[string]interface{}{},
-			CurrentSample:   map[string]interface{}{"/non-rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/non-rate"},
+			Name:   "leave-mismatching-new",
+			Fields: map[string]string{"/rate": "/non-rate"},
+			Samples: []sample{
+				{},
+				{"/non-rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/non-rate": int64(50)},
 		},
 		{
-			Name:            "leave-mismatching-existing",
-			Fields:          map[string]string{"/rate": "/non-rate"},
-			LastSample:      map[string]interface{}{"/non-rate": 45},
-			CurrentSample:   map[string]interface{}{"/non-rate": 50},
-			TimeDelta:       5 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/non-rate", "/rate"},
+			Name:   "leave-mismatching-existing",
+			Fields: map[string]string{"/rate": "/non-rate"},
+			Samples: []sample{
+				{"/non-rate": 45},
+				{"/non-rate": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/non-rate": int64(50), "/rate": float64(1)},
 		},
 		{
-			Name:            "leave-mismatching-expired",
-			Fields:          map[string]string{"/rate": "/non-rate"},
-			LastSample:      map[string]interface{}{"/non-rate": 45},
-			CurrentSample:   map[string]interface{}{"/non-rate": 50},
-			TimeDelta:       6 * time.Second,
-			RemoveOriginal:  false,
-			RemainingFields: []string{"/non-rate"},
+			Name:   "leave-mismatching-expired",
+			Fields: map[string]string{"/rate": "/non-rate"},
+			Samples: []sample{
+				{"/non-rate": 45},
+				{"/non-rate": 50},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: false,
+			Result:         sample{"/non-rate": int64(50)},
+		},
+
+		{
+			Name:           "previous-new",
+			Fields:         map[string]string{"/rate": "/total"},
+			PreviousFields: map[string]string{"/previous": "/rate"},
+			Samples: []sample{
+				{"/total": 50},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
+		},
+		{
+			Name:           "previous-new-no-previous-value",
+			Fields:         map[string]string{"/rate": "/total"},
+			PreviousFields: map[string]string{"/previous": "/rate"},
+			Samples: []sample{
+				{"/total": 50},
+				{"/total": 55},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/rate": float64(1)},
+		},
+		{
+			Name:           "previous-new-previous-value",
+			Fields:         map[string]string{"/rate": "/total"},
+			PreviousFields: map[string]string{"/previous": "/rate"},
+			Samples: []sample{
+				{"/total": 45},
+				{"/total": 55},
+				{"/total": 60},
+			},
+			TimeDelta:      5 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{"/rate": float64(1), "/previous": float64(2)},
+		},
+		{
+			Name:           "previous-matching-expired",
+			Fields:         map[string]string{"/rate": "/total"},
+			PreviousFields: map[string]string{"/previous": "/rate"},
+			Samples: []sample{
+				{"/total": 45},
+				{"/total": 50},
+				{"/total": 55},
+			},
+			TimeDelta:      6 * time.Second,
+			RemoveOriginal: true,
+			Result:         sample{},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
+			assert.True(t, len(testCase.Samples) > 0)
+
 			r := newTransform()
 			r.Fields = testCase.Fields
+			r.PreviousFields = testCase.PreviousFields
 			r.RemoveOriginal = testCase.RemoveOriginal
 			r.Expiration.Duration = 5 * time.Second
+			r.Log = testutil.Logger{}
 			assert.Nil(t, r.Init())
 
 			t1 := time.Now()
-			m1 := newMetric("foo", nil, testCase.LastSample, t1)
-			m2 := newMetric("foo", nil, testCase.CurrentSample, t1.Add(testCase.TimeDelta))
-
-			r.Apply(m1)
-			result := r.Apply(m2)[0]
-
-			assert.Len(t, result.FieldList(), len(testCase.RemainingFields))
-
-			for _, field := range testCase.RemainingFields {
-				_, exists := result.GetField(field)
-				assert.Truef(t, exists, "the field '%v' doesn't exist", field)
+			for i := 0; i < len(testCase.Samples)-1; i++ {
+				timestamp := t1.Add(time.Duration(i) * testCase.TimeDelta)
+				r.Apply(newMetric("foo", nil, testCase.Samples[i], timestamp))
 			}
+
+			m := newMetric("foo", nil,
+				testCase.Samples[len(testCase.Samples)-1],
+				t1.Add(testCase.TimeDelta*time.Duration(len(testCase.Samples)-1)),
+			)
+
+			result := r.Apply(m)[0]
+
+			assert.Equal(t, result.Fields(), testCase.Result)
 		})
 	}
 }
@@ -343,6 +424,22 @@ func TestFailsOnConflictingFieldMappings(t *testing.T) {
 			}
 
 			assert.EqualError(t, r.Init(), "both '/my/other/rate' and '/my/rate' are configured to be calculated from '/my/total'")
+		})
+	}
+}
+
+func TestFailsMissingPreviousSource(t *testing.T) {
+	for _, transformType := range transformTypes {
+		t.Run(transformType, func(t *testing.T) {
+			r := newTransformType(transformType)
+			r.Fields = map[string]string{
+				"/my/rate": "/my/total",
+			}
+			r.PreviousFields = map[string]string{
+				"/my/previous": "/my/missing",
+			}
+
+			assert.EqualError(t, r.Init(), "the previous field '/my/previous' references a transformed field '/my/missing' which does not exist")
 		})
 	}
 }


### PR DESCRIPTION
## Description

The state change transform will detect changes in a field and only pass that field along if a change took place. It will pass the first observed value (start-up) and the first value observed after "expiration" if the expiration is specified.