### PR TITLE
Support absolute path to extract tags/fields in graph collector

### DIFF
--- a/plugins/inputs/t128_graphql/README.md
+++ b/plugins/inputs/t128_graphql/README.md
@@ -26,22 +26,23 @@ The graphql input plugin collects data from a 128T instance via graphQL.
 # timeout = "5s"
 
 ## Required. The fields to collect with the desired name as the key (left) and the graphQL 
-## query path relative to the entry_point as the value (right).
+## query path as the value (right). The path can be relative to the entry point or an absolute
+## path that does not diverge from the entry-point and does not contain graphQL arguments such
+## as (name:'RTR_EAST_COMBO').
 # [inputs.t128_graphql.extract_fields]
 #   is-active = "paths/isActive"
 #   status = "paths/status"
+#   other = "allRouters/nodes/other-field"  # absolute path
 
 ## The tags for filtering data with the desired name as the key (left) and the graphQL 
-## query path relative to the entry_point as the value (right).
+## query path as the value (right). The path can be relative to the entry point or an absolute
+## path that does not diverge from the entry-point and does not contain graphQL arguments such
+## as (name:'RTR_EAST_COMBO').
 # [inputs.t128_graphql.extract_tags]
 #   peer-name = "name"
 #   device-interface = "paths/deviceInterface"
+#   router-name = "allRouters/nodes/name"  # absolute path
 
-## Other tags for filtering data with the desired name as the key (left) and the FULL graphQL 
-## query path as the value (right). The path should be a subpath of the entry_point but exclude
-## any desired graphQL arguments such as (name:'RTR_EAST_COMBO').
-# [inputs.t128_graphql.other_tags]
-#   router-name = "allRouters/nodes/name"
 ```
 
 ### Example GraphQL Query
@@ -52,6 +53,7 @@ query {
   allRouters(name: "RTR_EAST_COMBO") {
     nodes {
       name
+      other-field
       peers {
         nodes {
           name
@@ -77,6 +79,7 @@ For the query above, an example graphQL response is:
       "nodes": [
         {
           "name": "RTR_EAST_COMBO",
+          "other-field": "foo",
           "peers": {
             "nodes": [
               {
@@ -107,6 +110,6 @@ For the query above, an example graphQL response is:
 For the response above, the collector outputs:
 
 ```
-peer-paths,router-name=RTR_EAST_COMBO,device-interface=10,peer-name=fake is-active=true,status="DOWN" 1617285085000000000
-peer-paths,router-name=RTR_EAST_COMBO,device-interface=11,peer-name=fake is-active=true,status="UP" 1617285085000000000
+peer-paths,router-name=RTR_EAST_COMBO,device-interface=10,peer-name=fake other="foo",is-active=true,status="DOWN" 1617285085000000000
+peer-paths,router-name=RTR_EAST_COMBO,device-interface=11,peer-name=fake other="foo",is-active=true,status="UP" 1617285085000000000
 ```

--- a/plugins/inputs/t128_graphql/README.md
+++ b/plugins/inputs/t128_graphql/README.md
@@ -36,6 +36,12 @@ The graphql input plugin collects data from a 128T instance via graphQL.
 # [inputs.t128_graphql.extract_tags]
 #   peer-name = "name"
 #   device-interface = "paths/deviceInterface"
+
+## Other tags for filtering data with the desired name as the key (left) and the FULL graphQL 
+## query path as the value (right). The path should be a subpath of the entry_point but exclude
+## any desired graphQL arguments such as (name:'RTR_EAST_COMBO').
+# [inputs.t128_graphql.other_tags]
+#   router-name = "allRouters/nodes/name"
 ```
 
 ### Example GraphQL Query
@@ -45,6 +51,7 @@ For the configuration above, the plugin will build the following graphQL query:
 query {
   allRouters(name: "RTR_EAST_COMBO") {
     nodes {
+      name
       peers {
         nodes {
           name
@@ -69,6 +76,7 @@ For the query above, an example graphQL response is:
     "allRouters": {
       "nodes": [
         {
+          "name": "RTR_EAST_COMBO",
           "peers": {
             "nodes": [
               {
@@ -99,6 +107,6 @@ For the query above, an example graphQL response is:
 For the response above, the collector outputs:
 
 ```
-peer-paths,device-interface=10,peer-name=fake is-active=true,status="DOWN" 1617285085000000000
-peer-paths,device-interface=11,peer-name=fake is-active=true,status="UP" 1617285085000000000
+peer-paths,router-name=RTR_EAST_COMBO,device-interface=10,peer-name=fake is-active=true,status="DOWN" 1617285085000000000
+peer-paths,router-name=RTR_EAST_COMBO,device-interface=11,peer-name=fake is-active=true,status="UP" 1617285085000000000
 ```

--- a/plugins/inputs/t128_graphql/config.go
+++ b/plugins/inputs/t128_graphql/config.go
@@ -32,7 +32,13 @@ Example:
 		Tags:   map[string]string{".data.allRouters.nodes.nodes.nodes.arp.nodes.test-tag": "test-tag"},
 	}
 */
-func LoadConfig(entryPoint string, fieldsIn map[string]string, tagsIn map[string]string, otherTags map[string]string) *Config {
+func LoadConfig(
+	entryPoint string,
+	fieldsWithPartialPath map[string]string,
+	fieldsWithAbsPath map[string]string,
+	tagsWithPartialPath map[string]string,
+	tagsWithAbsPath map[string]string,
+) *Config {
 	config := &Config{}
 	path := ".data."
 	predicates := map[string]string{}
@@ -51,15 +57,16 @@ func LoadConfig(entryPoint string, fieldsIn map[string]string, tagsIn map[string
 	}
 
 	config.Predicates = predicates
-	config.Fields = formatPaths(fieldsIn, path)
-	config.Tags = formatPaths(tagsIn, path)
-	addOtherTags(config.Tags, otherTags)
+	config.Fields = formatPaths(fieldsWithPartialPath, path)
+	addDataWithAbsPath(config.Fields, fieldsWithAbsPath)
+	config.Tags = formatPaths(tagsWithPartialPath, path)
+	addDataWithAbsPath(config.Tags, tagsWithAbsPath)
 
 	return config
 }
 
-func addOtherTags(currentTags map[string]string, otherTags map[string]string) map[string]string {
-	for key, val := range formatPaths(otherTags, ".data.") {
+func addDataWithAbsPath(currentTags map[string]string, tagsWithAbsPath map[string]string) map[string]string {
+	for key, val := range formatPaths(tagsWithAbsPath, ".data.") {
 		currentTags[key] = val
 	}
 	return currentTags

--- a/plugins/inputs/t128_graphql/config.go
+++ b/plugins/inputs/t128_graphql/config.go
@@ -34,9 +34,9 @@ Example:
 */
 func LoadConfig(
 	entryPoint string,
-	fieldsWithPartialPath map[string]string,
+	fieldsWithRelPath map[string]string,
 	fieldsWithAbsPath map[string]string,
-	tagsWithPartialPath map[string]string,
+	tagsWithRelPath map[string]string,
 	tagsWithAbsPath map[string]string,
 ) *Config {
 	config := &Config{}
@@ -57,9 +57,9 @@ func LoadConfig(
 	}
 
 	config.Predicates = predicates
-	config.Fields = formatPaths(fieldsWithPartialPath, path)
+	config.Fields = formatPaths(fieldsWithRelPath, path)
 	addDataWithAbsPath(config.Fields, fieldsWithAbsPath)
-	config.Tags = formatPaths(tagsWithPartialPath, path)
+	config.Tags = formatPaths(tagsWithRelPath, path)
 	addDataWithAbsPath(config.Tags, tagsWithAbsPath)
 
 	return config

--- a/plugins/inputs/t128_graphql/config.go
+++ b/plugins/inputs/t128_graphql/config.go
@@ -32,7 +32,7 @@ Example:
 		Tags:   map[string]string{".data.allRouters.nodes.nodes.nodes.arp.nodes.test-tag": "test-tag"},
 	}
 */
-func LoadConfig(entryPoint string, fieldsIn map[string]string, tagsIn map[string]string) *Config {
+func LoadConfig(entryPoint string, fieldsIn map[string]string, tagsIn map[string]string, otherTags map[string]string) *Config {
 	config := &Config{}
 	path := ".data."
 	predicates := map[string]string{}
@@ -53,8 +53,16 @@ func LoadConfig(entryPoint string, fieldsIn map[string]string, tagsIn map[string
 	config.Predicates = predicates
 	config.Fields = formatPaths(fieldsIn, path)
 	config.Tags = formatPaths(tagsIn, path)
+	addOtherTags(config.Tags, otherTags)
 
 	return config
+}
+
+func addOtherTags(currentTags map[string]string, otherTags map[string]string) map[string]string {
+	for key, val := range formatPaths(otherTags, ".data.") {
+		currentTags[key] = val
+	}
+	return currentTags
 }
 
 //needed because users configure tags & fields with paths starting at entry_point with "/" instead of "."

--- a/plugins/inputs/t128_graphql/config_test.go
+++ b/plugins/inputs/t128_graphql/config_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 var JSONPathFormationTestCases = []struct {
-	Name           string
-	EntryPoint     string
-	Fields         map[string]string
-	Tags           map[string]string
-	OtherTags      map[string]string
-	ExpectedOutput *plugin.Config
+	Name              string
+	EntryPoint        string
+	Fields            map[string]string
+	FieldsWithAbsPath map[string]string
+	Tags              map[string]string
+	TagsWithAbsPath   map[string]string
+	ExpectedOutput    *plugin.Config
 }{
 	{
 		Name:           "process simple input",
@@ -37,14 +38,17 @@ var JSONPathFormationTestCases = []struct {
 		ExpectedOutput: getTestConfigWithPredicates("(names:[\"wan\",\"lan\"],key2:\"value2\")", "(name:\"east-combo\")"),
 	},
 	{
-		Name:       "process config with other tags",
+		Name:       "process config with absolute path tags and fields",
 		EntryPoint: "allServices/nodes/timeSeriesAnalytic(metric: BANDWIDTH, router: '${ROUTER}', transform: AVERAGE, resolution: 1000, startTime: 'now-180', endTime: 'now')",
 		Fields: map[string]string{
 			"value":     "value",
 			"timestamp": "timestamp",
 		},
+		FieldsWithAbsPath: map[string]string{
+			"other-field": "allServices/nodes/other",
+		},
 		Tags: getTestTags(),
-		OtherTags: map[string]string{
+		TagsWithAbsPath: map[string]string{
 			"name": "allServices/nodes/name",
 		},
 		ExpectedOutput: &plugin.Config{
@@ -54,6 +58,7 @@ var JSONPathFormationTestCases = []struct {
 			Fields: map[string]string{
 				".data.allServices.nodes.timeSeriesAnalytic.value":     "value",
 				".data.allServices.nodes.timeSeriesAnalytic.timestamp": "timestamp",
+				".data.allServices.nodes.other":                        "other-field",
 			},
 			Tags: map[string]string{
 				".data.allServices.nodes.timeSeriesAnalytic.test-tag": "test-tag",
@@ -84,7 +89,13 @@ func getTestConfigWithPredicates(pred1 string, pred2 string) *plugin.Config {
 func TestT128GraphqlEntryPointParsing(t *testing.T) {
 	for _, testCase := range JSONPathFormationTestCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			parsedEntryPoint := plugin.LoadConfig(testCase.EntryPoint, testCase.Fields, testCase.Tags, testCase.OtherTags)
+			parsedEntryPoint := plugin.LoadConfig(
+				testCase.EntryPoint,
+				testCase.Fields,
+				testCase.FieldsWithAbsPath,
+				testCase.Tags,
+				testCase.TagsWithAbsPath,
+			)
 			require.Equal(t, testCase.ExpectedOutput, parsedEntryPoint)
 		})
 	}

--- a/plugins/inputs/t128_graphql/query_builder_test.go
+++ b/plugins/inputs/t128_graphql/query_builder_test.go
@@ -180,7 +180,7 @@ var QueryFormationTestCases = []struct {
 			test-field}}}}}}}`, "\t", ""),
 	},
 	{
-		Name: "build query with other tags",
+		Name: "build query with absolute path tags and fields",
 		ConfigIn: &plugin.Config{
 			Predicates: map[string]string{
 				".data.allServices.nodes.timeSeriesAnalytic.$predicate": "(metric:BANDWIDTH,router:\"${ROUTER}\",transform:AVERAGE,resolution:1000,startTime:\"now-180\",endTime:\"now\")",
@@ -188,6 +188,7 @@ var QueryFormationTestCases = []struct {
 			Fields: map[string]string{
 				".data.allServices.nodes.timeSeriesAnalytic.value":     "value",
 				".data.allServices.nodes.timeSeriesAnalytic.timestamp": "timestamp",
+				".data.allServices.nodes.other":                        "other-field",
 			},
 			Tags: map[string]string{
 				".data.allServices.nodes.timeSeriesAnalytic.test-tag": "test-tag",
@@ -198,6 +199,7 @@ var QueryFormationTestCases = []struct {
 			allServices{
 			nodes{
 			name
+			other
 			timeSeriesAnalytic(metric:BANDWIDTH,router:"${ROUTER}",transform:AVERAGE,resolution:1000,startTime:"now-180",endTime:"now"){
 			test-tag
 			timestamp

--- a/plugins/inputs/t128_graphql/query_builder_test.go
+++ b/plugins/inputs/t128_graphql/query_builder_test.go
@@ -179,6 +179,30 @@ var QueryFormationTestCases = []struct {
 			test-tag-1}
 			test-field}}}}}}}`, "\t", ""),
 	},
+	{
+		Name: "build query with other tags",
+		ConfigIn: &plugin.Config{
+			Predicates: map[string]string{
+				".data.allServices.nodes.timeSeriesAnalytic.$predicate": "(metric:BANDWIDTH,router:\"${ROUTER}\",transform:AVERAGE,resolution:1000,startTime:\"now-180\",endTime:\"now\")",
+			},
+			Fields: map[string]string{
+				".data.allServices.nodes.timeSeriesAnalytic.value":     "value",
+				".data.allServices.nodes.timeSeriesAnalytic.timestamp": "timestamp",
+			},
+			Tags: map[string]string{
+				".data.allServices.nodes.timeSeriesAnalytic.test-tag": "test-tag",
+				".data.allServices.nodes.name":                        "name",
+			},
+		},
+		ExpectedQuery: strings.ReplaceAll(`query {
+			allServices{
+			nodes{
+			name
+			timeSeriesAnalytic(metric:BANDWIDTH,router:"${ROUTER}",transform:AVERAGE,resolution:1000,startTime:"now-180",endTime:"now"){
+			test-tag
+			timestamp
+			value}}}}`, "\t", ""),
+	},
 }
 
 func TestT128GraphqlQueryFormation(t *testing.T) {

--- a/plugins/inputs/t128_graphql/response_processor_test.go
+++ b/plugins/inputs/t128_graphql/response_processor_test.go
@@ -345,10 +345,11 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedError: nil,
 	},
 	{
-		Name: "process response with other tags",
+		Name: "process response for tags and fields with absolute path",
 		Fields: map[string]string{
 			".data.allServices.nodes.timeSeriesAnalytic.value":     "value",
 			".data.allServices.nodes.timeSeriesAnalytic.timestamp": "timestamp",
+			".data.allServices.nodes.other":                        "other-field",
 		},
 		Tags: map[string]string{
 			".data.allServices.nodes.timeSeriesAnalytic.test-tag": "test-tag",
@@ -360,6 +361,7 @@ var ResponseProcessingTestCases = []struct {
 				"nodes": [
 				  {
 					"name": "east",
+					"other": "moo",
 					"timeSeriesAnalytic": [
 					  {
 						"timestamp": "2021-06-14T21:10:00Z",
@@ -370,6 +372,7 @@ var ResponseProcessingTestCases = []struct {
 				  },
 				  {
 					"name": "west",
+					"other": "cow",
 					"timeSeriesAnalytic": [
 					  {
 						"timestamp": "2021-06-14T21:10:00Z",
@@ -385,8 +388,9 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedOutput: []*plugin.ProcessedResponse{
 			{
 				Fields: map[string]interface{}{
-					"value":     "0",
-					"timestamp": "2021-06-14T21:10:00Z",
+					"value":       "0",
+					"timestamp":   "2021-06-14T21:10:00Z",
+					"other-field": "moo",
 				},
 				Tags: map[string]string{
 					"test-tag": "foo",
@@ -395,8 +399,9 @@ var ResponseProcessingTestCases = []struct {
 			},
 			{
 				Fields: map[string]interface{}{
-					"value":     "128",
-					"timestamp": "2021-06-14T21:10:00Z",
+					"value":       "128",
+					"timestamp":   "2021-06-14T21:10:00Z",
+					"other-field": "cow",
 				},
 				Tags: map[string]string{
 					"test-tag": "bar",

--- a/plugins/inputs/t128_graphql/response_processor_test.go
+++ b/plugins/inputs/t128_graphql/response_processor_test.go
@@ -41,7 +41,7 @@ var ResponseProcessingTestCases = []struct {
 				"test-tag": "test-string"
 			}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{},
 				Tags:   map[string]string{"test-tag": "test-string"},
 			},
@@ -57,7 +57,7 @@ var ResponseProcessingTestCases = []struct {
 				"test-tag": 128
 			}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 128.0},
 				Tags:   map[string]string{"test-tag": "128"},
 			},
@@ -74,7 +74,7 @@ var ResponseProcessingTestCases = []struct {
 				"test-tag": "test-string"
 	  		}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field-1": 128.0, "test-field-2": 95.0},
 				Tags:   map[string]string{"test-tag": "test-string"},
 			},
@@ -91,7 +91,7 @@ var ResponseProcessingTestCases = []struct {
 		  		"test-tag-2": "test-string-2"
 	  		}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 128.0},
 				Tags:   map[string]string{"test-tag-1": "test-string-1", "test-tag-2": "test-string-2"},
 			},
@@ -108,7 +108,7 @@ var ResponseProcessingTestCases = []struct {
 		  		"test-tag-2": null
 	  		}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 128.0},
 				Tags:   map[string]string{"test-tag-1": "test-string-1"},
 			},
@@ -124,7 +124,7 @@ var ResponseProcessingTestCases = []struct {
 				"test-tag": 128
 			}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field-renamed": 128.0},
 				Tags:   map[string]string{"test-tag-renamed": "128"},
 			},
@@ -145,11 +145,11 @@ var ResponseProcessingTestCases = []struct {
 				"test-tag": "test-string-2"
 			}]}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 128.0},
 				Tags:   map[string]string{"test-tag": "test-string-1"},
 			},
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 95.0},
 				Tags:   map[string]string{"test-tag": "test-string-2"},
 			},
@@ -177,11 +177,11 @@ var ResponseProcessingTestCases = []struct {
 			}
 		]}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 128.0},
 				Tags:   map[string]string{"test-tag-1": "test-string-1", "test-tag-2": "test-string-2"},
 			},
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 95.0},
 				Tags:   map[string]string{"test-tag-1": "test-string-3", "test-tag-2": "test-string-4"},
 			},
@@ -204,7 +204,7 @@ var ResponseProcessingTestCases = []struct {
 			  	}
 		  	}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 128.0},
 				Tags:   map[string]string{"test-tag-1": "test-string-1", "test-tag-2": "test-string-2"},
 			},
@@ -227,7 +227,7 @@ var ResponseProcessingTestCases = []struct {
 			  	}
 		  	}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field-1": 95.0, "test-field-2": 128.0},
 				Tags:   map[string]string{"test-tag": "test-string-1"},
 			},
@@ -250,7 +250,7 @@ var ResponseProcessingTestCases = []struct {
 			  	}
 		  	}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"test-field": 128.0},
 				Tags:   map[string]string{"test-tag-1": "test-string-1", "test-tag-2": "test-string-2"},
 			},
@@ -325,21 +325,83 @@ var ResponseProcessingTestCases = []struct {
 			  }
 		}}`)),
 		ExpectedOutput: []*plugin.ProcessedResponse{
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"adjacent-address": "12.51.52.30", "is-active": true, "uptime": 188333176.0},
 				Tags:   map[string]string{"peer-name": "AZDCBBP1", "device-interface": "StoreLTE", "vlan": "0"},
 			},
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"adjacent-address": "12.51.52.30", "is-active": true, "uptime": 82247253.0},
 				Tags:   map[string]string{"peer-name": "AZDCBBP1", "device-interface": "StoreWAN", "vlan": "0"},
 			},
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"adjacent-address": "12.51.52.22", "is-active": true, "uptime": 162241794.0},
 				Tags:   map[string]string{"peer-name": "AZDCLTEP1", "device-interface": "StoreLTE", "vlan": "0"},
 			},
-			&plugin.ProcessedResponse{
+			{
 				Fields: map[string]interface{}{"adjacent-address": "12.51.52.22", "is-active": true, "uptime": 82247352.0},
 				Tags:   map[string]string{"peer-name": "AZDCLTEP1", "device-interface": "StoreWAN", "vlan": "0"},
+			},
+		},
+		ExpectedError: nil,
+	},
+	{
+		Name: "process response with other tags",
+		Fields: map[string]string{
+			".data.allServices.nodes.timeSeriesAnalytic.value":     "value",
+			".data.allServices.nodes.timeSeriesAnalytic.timestamp": "timestamp",
+		},
+		Tags: map[string]string{
+			".data.allServices.nodes.timeSeriesAnalytic.test-tag": "test-tag",
+			".data.allServices.nodes.name":                        "name",
+		},
+		JsonInput: generateJsonTestData([]byte(`{
+			"data": {
+			  "allServices": {
+				"nodes": [
+				  {
+					"name": "east",
+					"timeSeriesAnalytic": [
+					  {
+						"timestamp": "2021-06-14T21:10:00Z",
+						"value": "0",
+						"test-tag": "foo"
+					  }
+					]
+				  },
+				  {
+					"name": "west",
+					"timeSeriesAnalytic": [
+					  {
+						"timestamp": "2021-06-14T21:10:00Z",
+						"value": "128",
+						"test-tag": "bar"
+					  }
+					]
+				  }
+				]
+			  }
+			}
+		  }`)),
+		ExpectedOutput: []*plugin.ProcessedResponse{
+			{
+				Fields: map[string]interface{}{
+					"value":     "0",
+					"timestamp": "2021-06-14T21:10:00Z",
+				},
+				Tags: map[string]string{
+					"test-tag": "foo",
+					"name":     "east",
+				},
+			},
+			{
+				Fields: map[string]interface{}{
+					"value":     "128",
+					"timestamp": "2021-06-14T21:10:00Z",
+				},
+				Tags: map[string]string{
+					"test-tag": "bar",
+					"name":     "west",
+				},
 			},
 		},
 		ExpectedError: nil,

--- a/plugins/inputs/t128_graphql/sample.go
+++ b/plugins/inputs/t128_graphql/sample.go
@@ -21,20 +21,20 @@ var sampleConfig = `
 # timeout = "5s"
 
 ## Required. The fields to collect with the desired name as the key (left) and the graphQL 
-## query path relative to the entry_point as the value (right).
+## query path as the value (right). The path can be relative to the entry point or an absolute
+## path that does not diverge from the entry-point and does not contain graphQL arguments such
+## as (name:'RTR_EAST_COMBO').
 # [inputs.t128_graphql.extract_fields]
 #   is-active = "paths/isActive"
 #   status = "paths/status"
+#   other = "allRouters/nodes/other-field"  # absolute path
 
 ## The tags for filtering data with the desired name as the key (left) and the graphQL 
-## query path relative to the entry_point as the value (right).
+## query path as the value (right). The path can be relative to the entry point or an absolute
+## path that does not diverge from the entry-point and does not contain graphQL arguments such
+## as (name:'RTR_EAST_COMBO').
 # [inputs.t128_graphql.extract_tags]
 #   peer-name = "name"
 #   device-interface = "paths/deviceInterface"
-
-## Other tags for filtering data with the desired name as the key (left) and the FULL graphQL 
-## query path as the value (right). The path should be a subpath of the entry_point but exclude
-## any desired graphQL arguments such as (name:'RTR_EAST_COMBO').
-# [inputs.t128_graphql.other_tags]
-#   router-name = "allRouters/nodes/name"
+#   router-name = "allRouters/nodes/name"  # absolute path
 `

--- a/plugins/inputs/t128_graphql/sample.go
+++ b/plugins/inputs/t128_graphql/sample.go
@@ -31,4 +31,10 @@ var sampleConfig = `
 # [inputs.t128_graphql.extract_tags]
 #   peer-name = "name"
 #   device-interface = "paths/deviceInterface"
+
+## Other tags for filtering data with the desired name as the key (left) and the FULL graphQL 
+## query path as the value (right). The path should be a subpath of the entry_point but exclude
+## any desired graphQL arguments such as (name:'RTR_EAST_COMBO').
+# [inputs.t128_graphql.other_tags]
+#   router-name = "allRouters/nodes/name"
 `

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -57,21 +57,21 @@ func (plugin *T128GraphQL) Init() error {
 		return err
 	}
 
-	fieldsWithPartialPath, fieldsWithAbsPath, err := validateAndSeparateData(plugin.Fields, plugin.EntryPoint)
+	fieldsWithRelPath, fieldsWithAbsPath, err := validateAndSeparatePaths(plugin.Fields, plugin.EntryPoint)
 	if err != nil {
 		return err
 	}
 
-	tagsWithPartialPath, tagsWithAbsPath, err := validateAndSeparateData(plugin.Tags, plugin.EntryPoint)
+	tagsWithRelPath, tagsWithAbsPath, err := validateAndSeparatePaths(plugin.Tags, plugin.EntryPoint)
 	if err != nil {
 		return err
 	}
 
 	plugin.Config = LoadConfig(
 		plugin.EntryPoint,
-		fieldsWithPartialPath,
+		fieldsWithRelPath,
 		fieldsWithAbsPath,
-		tagsWithPartialPath,
+		tagsWithRelPath,
 		tagsWithAbsPath,
 	)
 
@@ -238,10 +238,10 @@ func decodeAndReportJSONErrors(response []byte, template string) []error {
 	return errors
 }
 
-func validateAndSeparateData(data map[string]string, entryPoint string) (map[string]string, map[string]string, error) {
+func validateAndSeparatePaths(data map[string]string, entryPoint string) (map[string]string, map[string]string, error) {
 	predicateRegex := regexp.MustCompile(`\(.*?\)`)
 	cleanEntryPoint := predicateRegex.ReplaceAllString(entryPoint, "")
-	dataWithPartialPath := make(map[string]string)
+	dataWithRelPath := make(map[string]string)
 	dataWithAbsPath := make(map[string]string)
 
 	for name, path := range data {
@@ -256,14 +256,14 @@ func validateAndSeparateData(data map[string]string, entryPoint string) (map[str
 		}
 
 		if !strings.HasPrefix(cleanEntryPoint, pathToLeaf) {
-			dataWithPartialPath[name] = path
+			dataWithRelPath[name] = path
 			continue
 		}
 
 		dataWithAbsPath[name] = path
 	}
 
-	return dataWithPartialPath, dataWithAbsPath, nil
+	return dataWithRelPath, dataWithAbsPath, nil
 }
 
 func init() {

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -23,16 +23,16 @@ type Endpoint struct {
 }
 
 const (
-	ValidExpectedRequestSingleTag = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"}`
-	ValidQuerySingleTag           = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"
-	ValidExpectedRequestNoTag     = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field}}}}}}}"}`
-	ValidQueryNoTag               = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field}}}}}}}"
-	ValidExpectedRequestOtherTag  = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nname\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"}`
-	ValidQueryOtherTag            = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nname\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"
-	InvalidRouterExpectedRequest  = `{"query":"query {\nallRouters(name:\"not-a-router\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"}`
-	InvalidRouterQuery            = "query {\nallRouters(name:\"not-a-router\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"
-	InvalidFieldExpectedRequest   = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ninvalid-field\ntest-tag}}}}}}}"}`
-	InvalidFieldQuery             = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ninvalid-field\ntest-tag}}}}}}}"
+	ValidExpectedRequestSingleTag    = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"}`
+	ValidQuerySingleTag              = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"
+	ValidExpectedRequestNoTag        = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field}}}}}}}"}`
+	ValidQueryNoTag                  = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field}}}}}}}"
+	ValidExpectedRequestWithAbsPaths = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nname\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}\nname}}}}}"}`
+	ValidQueryWithAbsPaths           = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nname\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}\nname}}}}}"
+	InvalidRouterExpectedRequest     = `{"query":"query {\nallRouters(name:\"not-a-router\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"}`
+	InvalidRouterQuery               = "query {\nallRouters(name:\"not-a-router\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"
+	InvalidFieldExpectedRequest      = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ninvalid-field\ntest-tag}}}}}}}"}`
+	InvalidFieldQuery                = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ninvalid-field\ntest-tag}}}}}}}"
 )
 
 var CollectorTestCases = []struct {
@@ -40,7 +40,6 @@ var CollectorTestCases = []struct {
 	EntryPoint      string
 	Fields          map[string]string
 	Tags            map[string]string
-	OtherTags       map[string]string
 	InitError       bool
 	Query           string
 	Endpoint        Endpoint
@@ -62,20 +61,14 @@ var CollectorTestCases = []struct {
 		InitError:  true,
 	},
 	{
-		Name:       "other-tag with invalid path produces no request or metrics",
+		Name:       "tag with graphQL argument in path produces no request or metrics",
 		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:     map[string]string{"test-field": "test-field"},
-		Tags:       map[string]string{"test-tag": "test-tag"},
-		OtherTags:  map[string]string{"test-other-tag": "allServices/nodes/name"},
-		InitError:  true,
-	},
-	{
-		Name:       "other-tag with graphQL argument produces no request or metrics",
-		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
-		Fields:     map[string]string{"test-field": "test-field"},
-		Tags:       map[string]string{"test-tag": "test-tag"},
-		OtherTags:  map[string]string{"test-other-tag": "allRouters(name:'ComboEast')/nodes/name"},
-		InitError:  true,
+		Tags: map[string]string{
+			"test-tag":       "test-tag",
+			"other-test-tag": "allRouters(name:'ComboEast')/nodes/name",
+		},
+		InitError: true,
 	},
 	{
 		Name:            "empty response produces error",
@@ -164,7 +157,7 @@ var CollectorTestCases = []struct {
 		ExpectedErrors: nil,
 	},
 	{
-		Name:       "missing other-tags produces response", //complex processing tested separately
+		Name:       "missing tags/fields with absolute path produces response", //complex processing tested separately
 		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:     map[string]string{"test-field": "test-field"},
 		Tags:       map[string]string{"test-tag": "test-tag"},
@@ -199,17 +192,23 @@ var CollectorTestCases = []struct {
 	{
 		Name:       "full config produces response", //complex processing tested separately
 		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
-		Fields:     map[string]string{"test-field": "test-field"},
-		Tags:       map[string]string{"test-tag": "test-tag"},
-		OtherTags:  map[string]string{"test-other-tag": "allRouters/nodes/name"},
-		Query:      ValidQueryOtherTag,
-		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestOtherTag, `{
+		Fields: map[string]string{
+			"test-field":       "test-field",
+			"other-test-field": "allRouters/nodes/nodes/nodes/name",
+		},
+		Tags: map[string]string{
+			"test-tag":       "test-tag",
+			"other-test-tag": "allRouters/nodes/name",
+		},
+		Query: ValidQueryWithAbsPaths,
+		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestWithAbsPaths, `{
 			"data": {
 				"allRouters": {
 				  	"nodes": [{
 						"name": "ComboEast",
 					  	"nodes": {
 							"nodes": [{
+								"name": "east-combo",
 								"arp": {
 							  		"nodes": [{
 								  		"test-field": 128,
@@ -227,9 +226,12 @@ var CollectorTestCases = []struct {
 				Measurement: "test-collector",
 				Tags: map[string]string{
 					"test-tag":       "test-string-1",
-					"test-other-tag": "ComboEast",
+					"other-test-tag": "ComboEast",
 				},
-				Fields: map[string]interface{}{"test-field": 128.0},
+				Fields: map[string]interface{}{
+					"test-field":       128.0,
+					"other-test-field": "east-combo",
+				},
 			},
 		},
 		ExpectedErrors: nil,
@@ -248,7 +250,6 @@ func TestT128GraphqlCollector(t *testing.T) {
 				EntryPoint:    testCase.EntryPoint,
 				Fields:        testCase.Fields,
 				Tags:          testCase.Tags,
-				OtherTags:     testCase.OtherTags,
 			}
 
 			var acc testutil.Accumulator


### PR DESCRIPTION
# Description
Certain queries require tags/fields that are at a level lower than the `entry_point`. `extract_tags` and `extract_fields` will now support absolute paths to leafs making such queries possible.

# Testing
Unit
