### PR TITLE
Escaped invalid syslog characters for structured data parameters

### DIFF
--- a/plugins/outputs/syslog/syslog_mapper.go
+++ b/plugins/outputs/syslog/syslog_mapper.go
@@ -55,6 +55,9 @@ func (sm *SyslogMapper) mapStructuredDataItem(key string, value string, msg *rfc
 	if sm.reservedKeys[key] {
 		return
 	}
+
+	value = escapeInvalidCharacters(value)
+
 	isExplicitSdid := false
 	for _, sdid := range sm.Sdids {
 		k := strings.TrimLeft(key, sdid+sm.Separator)
@@ -196,4 +199,14 @@ func newSyslogMapper() *SyslogMapper {
 			"hostname": true, "source": true, "host": true, "severity": true,
 			"facility": true, "appname": true},
 	}
+}
+
+// escapeInvalidCharacters escapes the 3 characters that are invalid for structured data
+// parameter values as per the rfc5424 spec
+// https://datatracker.ietf.org/doc/html/rfc5424#section-6.3.3
+func escapeInvalidCharacters(input string) string {
+	input = strings.Replace(input, "\\", "\\\\", -1)
+	input = strings.Replace(input, "\"", "\\\"", -1)
+	input = strings.Replace(input, "]", "\\]", -1)
+	return input
 }

--- a/plugins/outputs/syslog/syslog_mapper_test.go
+++ b/plugins/outputs/syslog/syslog_mapper_test.go
@@ -123,6 +123,41 @@ func TestSyslogMapperWithDefaultSdid(t *testing.T) {
 	assert.Equal(t, "<27>2 2010-11-10T23:30:00Z testhost testapp 25 555 [default@32473 tag1=\"bar\" tag2=\"foobar\" value1=\"2\" value2=\"foo\" value3=\"1.2\"] Test message", str, "Wrong syslog message")
 }
 
+func TestSyslogMapperWithSDWithInvalidCharacters(t *testing.T) {
+	s := newSyslog()
+	s.DefaultSdid = "default@32473"
+	s.initializeSyslogMapper()
+
+	// Init metrics
+	m1, _ := metric.New(
+		"testmetric",
+		map[string]string{
+			"appname":            "testapp",
+			"hostname":           "testhost",
+			"tag1":               "\"\\]",
+			"default@32473_tag2": "foobar",
+		},
+		map[string]interface{}{
+			"severity_code":        uint64(3),
+			"facility_code":        uint64(3),
+			"msg":                  "Test message",
+			"procid":               uint64(25),
+			"version":              uint16(2),
+			"msgid":                int64(555),
+			"timestamp":            time.Date(2010, time.November, 10, 23, 30, 0, 0, time.UTC).UnixNano(),
+			"value1":               "{\"some-json\":[]}",
+			"default@32473_value2": "foo",
+			"value3":               float64(1.2),
+		},
+		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC),
+	)
+
+	syslogMessage, err := s.mapper.MapMetricToSyslogMessage(m1)
+	require.NoError(t, err)
+	str, _ := syslogMessage.String()
+	assert.Equal(t, "<27>2 2010-11-10T23:30:00Z testhost testapp 25 555 [default@32473 tag1=\"\\\"\\\\\\]\" tag2=\"foobar\" value1=\"{\\\"some-json\\\":[\\]}\" value2=\"foo\" value3=\"1.2\"] Test message", str, "Wrong syslog message")
+}
+
 func TestSyslogMapperWithDefaultSdidAndOtherSdids(t *testing.T) {
 	s := newSyslog()
 	s.DefaultSdid = "default@32473"


### PR DESCRIPTION
[I95-43137](https://128technology.atlassian.net/browse/I95-43137)

Json that was passed through to syslog output was being turned into an empty string.

Just had to replace:
* `\` with `\\`
* `"` with `\"`
* `]` with `\]`
according to the rfc5424 spec. 
https://datatracker.ietf.org/doc/html/rfc5424#section-6.3.3 since those mess up the parsing of the true-to-spec go-syslog lib that telegraf uses.