### PR TITLE
Persist t128 transform state change cache

### DIFF
--- a/plugins/processors/t128_transform/README.md
+++ b/plugins/processors/t128_transform/README.md
@@ -7,41 +7,41 @@ The `t128_transform` transforms metrics based on the difference between two obse
 ```toml
 [[processors.t128_transform]]
   ## For 'rate' and 'diff', if more than this amount of time passes between
-	## data points, the previous value will be considered old and the value will
-	## be recalculated as if it hadn't been seen before. A zero expiration means
-	## never expire.
-	##
-	## When using the 'state-change' transform, an update metric will be sent
-	## upon expiration even if the value has not changed.
-	# expiration = "0s"
+  ## data points, the previous value will be considered old and the value will
+  ## be recalculated as if it hadn't been seen before. A zero expiration means
+  ## never expire.
+  ##
+  ## When using the 'state-change' transform, an update metric will be sent
+  ## upon expiration even if the value has not changed.
+  # expiration = "0s"
 
-	## The operation that should be performed between two observed points.
-	## It can be 'diff', 'rate', or 'state-change'.
-	# transform = "rate"
+  ## The operation that should be performed between two observed points.
+  ## It can be 'diff', 'rate', or 'state-change'.
+  # transform = "rate"
 
-	## For the fields who's key/value pairs don't match, should the original
-	## field be removed?
-	# remove-original = true
+  ## For the fields who's key/value pairs don't match, should the original
+  ## field be removed?
+  # remove-original = true
 
-	## Specify a field to be populated with the last produced value. If the
-	## field name is an empty string or there is no prior value, the field will
-	## be excluded.
-	# previous_field = ""
+  ## Specify a field to be populated with the last produced value. If the
+  ## field name is an empty string or there is no prior value, the field will
+  ## be excluded.
+  # previous_field = ""
 
-	## Specify a path to persist state across telegraf instance restarts.
-	## Only applicable for "state-change" transforms.
-	## A default of "" indicates that state will not be persisted.
-	# persist_to = ""
+  ## Specify a path to persist state across telegraf instance restarts.
+  ## Only applicable for "state-change" transforms.
+  ## A default of "" indicates that state will not be persisted.
+  # persist_to = ""
 
 [processors.t128_transform.fields]
-	## Replace fields with their computed values, renaming them if indicated
-	# "/rate/metric" = "/total/metric"
-	# "/inline/replace" = "/inline/replace"
+  ## Replace fields with their computed values, renaming them if indicated
+  # "/rate/metric" = "/total/metric"
+  # "/inline/replace" = "/inline/replace"
 
 [processors.t128_transform.previous_fields]
-	## Populate these fields with the previous transformed value. If there is no
-	## prior value, the field will be excluded.
-	# "/rate/metric/previous" = "/rate/metric"
+  ## Populate these fields with the previous transformed value. If there is no
+  ## prior value, the field will be excluded.
+  # "/rate/metric/previous" = "/rate/metric"
 ```
 
 ### Example Diff:

--- a/plugins/processors/t128_transform/README.md
+++ b/plugins/processors/t128_transform/README.md
@@ -6,23 +6,42 @@ The `t128_transform` transforms metrics based on the difference between two obse
 
 ```toml
 [[processors.t128_transform]]
-  ## If more than this amount of time passes between data points, the
-  ## previous value will be considered old and the value will be recalculated
-  ## as if it hadn't been seen before. A zero expiration means never expire.
-  # expiration = "0s"
+  ## For 'rate' and 'diff', if more than this amount of time passes between
+	## data points, the previous value will be considered old and the value will
+	## be recalculated as if it hadn't been seen before. A zero expiration means
+	## never expire.
+	##
+	## When using the 'state-change' transform, an update metric will be sent
+	## upon expiration even if the value has not changed.
+	# expiration = "0s"
 
-  ## The operation that should be performed between two observed points.
-  ## It can be 'diff' or 'rate'
-  # transform = "rate"
+	## The operation that should be performed between two observed points.
+	## It can be 'diff', 'rate', or 'state-change'.
+	# transform = "rate"
 
-  ## For the fields who's key/value pairs don't match, should the original
-  ## field be removed?
-  # remove-original = true
+	## For the fields who's key/value pairs don't match, should the original
+	## field be removed?
+	# remove-original = true
+
+	## Specify a field to be populated with the last produced value. If the
+	## field name is an empty string or there is no prior value, the field will
+	## be excluded.
+	# previous_field = ""
+
+	## Specify a path to persist state across telegraf instance restarts.
+	## Only applicable for "state-change" transforms.
+	## A default of "" indicates that state will not be persisted.
+	# persist_to = ""
 
 [processors.t128_transform.fields]
-  ## Replace fields with their computed values, renaming them if indicated
-  # "/rate/metric" = "/total/metric"
-  # "/inline/replace" = "/inline/replace"
+	## Replace fields with their computed values, renaming them if indicated
+	# "/rate/metric" = "/total/metric"
+	# "/inline/replace" = "/inline/replace"
+
+[processors.t128_transform.previous_fields]
+	## Populate these fields with the previous transformed value. If there is no
+	## prior value, the field will be excluded.
+	# "/rate/metric/previous" = "/rate/metric"
 ```
 
 ### Example Diff:

--- a/plugins/processors/t128_transform/t128_transform.go
+++ b/plugins/processors/t128_transform/t128_transform.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"os"
+	"path"
 	"sort"
 	"time"
 
@@ -95,6 +97,8 @@ func (r *T128Transform) Description() string {
 }
 
 func (r *T128Transform) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	cacheChanged := false
+
 	for _, point := range in {
 		seriesHash := point.HashID()
 
@@ -148,11 +152,17 @@ func (r *T128Transform) Apply(in ...telegraf.Metric) []telegraf.Metric {
 				newPrevious = value
 			}
 
-			r.cache[seriesHash][field.Key] = observedValue{
+			previous := r.cache[seriesHash][field.Key]
+			new := observedValue{
 				Value:     field.Value,
 				Previous:  newPrevious,
 				Expires:   point.Time().Add(r.Expiration.Duration),
 				Timestamp: point.Time(),
+			}
+			r.cache[seriesHash][field.Key] = new
+
+			if !cacheChanged && previous != new {
+				cacheChanged = true
 			}
 		}
 
@@ -161,7 +171,7 @@ func (r *T128Transform) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		}
 	}
 
-	if r.PersistTo != "" {
+	if cacheChanged {
 		err := persistCache(r.PersistTo, r.cache)
 		if err != nil {
 			r.Log.Warnf("unable to persist cache to %s: %s", r.PersistTo, err)
@@ -178,7 +188,9 @@ func (r *T128Transform) Init() error {
 
 	switch r.Transform {
 	case "diff":
-		r.PersistTo = ""
+		if r.PersistTo != "" {
+			return fmt.Errorf("'diff' transform does not support persistence")
+		}
 
 		r.transform = func(expired bool, t1, t2 time.Time, v1, v2 interface{}) (interface{}, bool, error) {
 			if expired || v1 == nil {
@@ -193,7 +205,9 @@ func (r *T128Transform) Init() error {
 			return current - prev, true, nil
 		}
 	case "rate":
-		r.PersistTo = ""
+		if r.PersistTo != "" {
+			return fmt.Errorf("'rate' transform does not support persistence")
+		}
 
 		r.transform = func(expired bool, t1, t2 time.Time, v1, v2 interface{}) (interface{}, bool, error) {
 			if expired || v1 == nil {
@@ -215,7 +229,6 @@ func (r *T128Transform) Init() error {
 			return (current - prev) / (t2.Sub(t1).Seconds()), true, nil
 		}
 	case "state-change":
-
 		if r.PersistTo != "" {
 			persistedCache, err := loadCache(r.PersistTo)
 			if err != nil {
@@ -279,10 +292,10 @@ func (r *T128Transform) Init() error {
 	return nil
 }
 
-func loadCache(path string) (map[uint64]map[string]observedValue, error) {
+func loadCache(cachePath string) (map[uint64]map[string]observedValue, error) {
 	cache := make(map[uint64]map[string]observedValue)
 
-	data, err := ioutil.ReadFile(path)
+	data, err := ioutil.ReadFile(cachePath)
 	if err != nil {
 		return cache, err
 	}
@@ -295,13 +308,19 @@ func loadCache(path string) (map[uint64]map[string]observedValue, error) {
 	return cache, nil
 }
 
-func persistCache(path string, cache map[uint64]map[string]observedValue) error {
-	file, err := json.MarshalIndent(cache, "", "  ")
+func persistCache(cachePath string, cache map[uint64]map[string]observedValue) error {
+	parentDir := path.Dir(cachePath)
+	err := os.MkdirAll(parentDir, os.ModePerm)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(path, file, 0644)
+	file, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(cachePath, file, 0644)
 	if err != nil {
 		return err
 	}

--- a/plugins/processors/t128_transform/t128_transform.go
+++ b/plugins/processors/t128_transform/t128_transform.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
-	"strings"
 	"sort"
 	"time"
 
@@ -39,6 +38,7 @@ const sampleConfig = `
 
 	## Specify a path to persist state across telegraf instance restarts.
 	## Only applicable for "state-change" transforms.
+	## A default of "" indicates that state will not be persisted.
 	# persist_to = ""
 
 [processors.t128_transform.fields]
@@ -78,60 +78,12 @@ type target struct {
 }
 
 type observedValue struct {
-	value interface{}
+	Value interface{}
 	// previous produced (transformed) value, not previous observed
 	// (the two would be the same in some cases)
-	previous  interface{}
-	expires   time.Time
-	timestamp time.Time
-}
-
-func (o observedValue) MarshalJSON() ([]byte, error) {
-	value := struct {
-		Value        interface{}  `json:"value"`
-		Previous     interface{}  `json:"previous"`
-		Expires      string       `json:"expires"`
-		Timestamp    string       `json:"timestamp"`
-	}{
-		Value:        o.value,
-		Previous:     o.previous,
-		Expires:      o.expires.Format(time.RFC3339),
-		Timestamp:    o.timestamp.Format(time.RFC3339),
-	}
-
-	return json.Marshal(value)
-}
-
-func (o *observedValue) UnmarshalJSON(j []byte) error {
-	var rawStrings map[string]interface{}
-
-	err := json.Unmarshal(j, &rawStrings)
-	if err != nil {
-		return err
-	}
-
-	for k, v := range rawStrings {
-		switch strings.ToLower(k) {
-		case "value":
-			o.value = v
-		case "previous":
-			o.previous = v
-		case "expires":
-			t, err := time.Parse(time.RFC3339, v.(string))
-			if err != nil {
-				return err
-			}
-			o.expires = t
-		case "timestamp":
-			t, err := time.Parse(time.RFC3339, v.(string))
-			if err != nil {
-				return err
-			}
-			o.timestamp = t
-		}
-	}
-
-	return nil
+	Previous  interface{}
+	Expires   time.Time
+	Timestamp time.Time
 }
 
 func (r *T128Transform) SampleConfig() string {
@@ -162,18 +114,18 @@ func (r *T128Transform) Apply(in ...telegraf.Metric) []telegraf.Metric {
 			observed, ok := cacheFields[field.Key]
 			if !ok {
 				observed = observedValue{
-					value: nil,
+					Value: nil,
 				}
 			}
 
-			expired := !point.Time().Before(observed.expires)
+			expired := !point.Time().Before(observed.Expires)
 
 			itemTransformed := false
 			value, recordAsPrevious, err := r.transform(
 				expired,
-				observed.timestamp,
+				observed.Timestamp,
 				point.Time(),
-				observed.value,
+				observed.Value,
 				field.Value,
 			)
 			if err != nil {
@@ -187,20 +139,20 @@ func (r *T128Transform) Apply(in ...telegraf.Metric) []telegraf.Metric {
 				removeFields = append(removeFields, field.Key)
 			}
 
-			if itemTransformed && target.previousKey != "" && observed.previous != nil {
-				point.AddField(target.previousKey, observed.previous)
+			if itemTransformed && target.previousKey != "" && observed.Previous != nil {
+				point.AddField(target.previousKey, observed.Previous)
 			}
 
-			newPrevious := observed.previous
+			newPrevious := observed.Previous
 			if recordAsPrevious {
 				newPrevious = value
 			}
 
 			r.cache[seriesHash][field.Key] = observedValue{
-				value:     field.Value,
-				previous:  newPrevious,
-				expires:   point.Time().Add(r.Expiration.Duration),
-				timestamp: point.Time(),
+				Value:     field.Value,
+				Previous:  newPrevious,
+				Expires:   point.Time().Add(r.Expiration.Duration),
+				Timestamp: point.Time(),
 			}
 		}
 
@@ -331,14 +283,14 @@ func loadCache(path string) (map[uint64]map[string]observedValue, error) {
 	cache := make(map[uint64]map[string]observedValue)
 
 	data, err := ioutil.ReadFile(path)
-    if err != nil {
-      return cache, err
-    }
+	if err != nil {
+		return cache, err
+	}
 
 	err = json.Unmarshal(data, &cache)
-    if err != nil {
-        return cache, err
-    }
+	if err != nil {
+		return cache, err
+	}
 
 	return cache, nil
 }

--- a/plugins/processors/t128_transform/t128_transform.go
+++ b/plugins/processors/t128_transform/t128_transform.go
@@ -1,8 +1,11 @@
 package t128_transform
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
+	"strings"
 	"sort"
 	"time"
 
@@ -34,6 +37,10 @@ const sampleConfig = `
 	## be excluded.
 	# previous_field = ""
 
+	## Specify a path to persist state across telegraf instance restarts.
+	## Only applicable for "state-change" transforms.
+	# persist_to = ""
+
 [processors.t128_transform.fields]
 	## Replace fields with their computed values, renaming them if indicated
 	# "/rate/metric" = "/total/metric"
@@ -55,6 +62,7 @@ type T128Transform struct {
 	Expiration     internal.Duration `toml:"expiration"`
 	RemoveOriginal bool              `toml:"remove-original"`
 	Transform      string            `toml:"transform"`
+	PersistTo      string            `toml:"persist_to"`
 
 	Log telegraf.Logger `toml:"-"`
 
@@ -76,6 +84,54 @@ type observedValue struct {
 	previous  interface{}
 	expires   time.Time
 	timestamp time.Time
+}
+
+func (o observedValue) MarshalJSON() ([]byte, error) {
+	value := struct {
+		Value        interface{}  `json:"value"`
+		Previous     interface{}  `json:"previous"`
+		Expires      string       `json:"expires"`
+		Timestamp    string       `json:"timestamp"`
+	}{
+		Value:        o.value,
+		Previous:     o.previous,
+		Expires:      o.expires.Format(time.RFC3339),
+		Timestamp:    o.timestamp.Format(time.RFC3339),
+	}
+
+	return json.Marshal(value)
+}
+
+func (o *observedValue) UnmarshalJSON(j []byte) error {
+	var rawStrings map[string]interface{}
+
+	err := json.Unmarshal(j, &rawStrings)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range rawStrings {
+		switch strings.ToLower(k) {
+		case "value":
+			o.value = v
+		case "previous":
+			o.previous = v
+		case "expires":
+			t, err := time.Parse(time.RFC3339, v.(string))
+			if err != nil {
+				return err
+			}
+			o.expires = t
+		case "timestamp":
+			t, err := time.Parse(time.RFC3339, v.(string))
+			if err != nil {
+				return err
+			}
+			o.timestamp = t
+		}
+	}
+
+	return nil
 }
 
 func (r *T128Transform) SampleConfig() string {
@@ -153,6 +209,13 @@ func (r *T128Transform) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		}
 	}
 
+	if r.PersistTo != "" {
+		err := persistCache(r.PersistTo, r.cache)
+		if err != nil {
+			r.Log.Warnf("unable to persist cache to %s: %s", r.PersistTo, err)
+		}
+	}
+
 	return in
 }
 
@@ -163,6 +226,8 @@ func (r *T128Transform) Init() error {
 
 	switch r.Transform {
 	case "diff":
+		r.PersistTo = ""
+
 		r.transform = func(expired bool, t1, t2 time.Time, v1, v2 interface{}) (interface{}, bool, error) {
 			if expired || v1 == nil {
 				return nil, true, nil
@@ -176,6 +241,8 @@ func (r *T128Transform) Init() error {
 			return current - prev, true, nil
 		}
 	case "rate":
+		r.PersistTo = ""
+
 		r.transform = func(expired bool, t1, t2 time.Time, v1, v2 interface{}) (interface{}, bool, error) {
 			if expired || v1 == nil {
 				return nil, true, nil
@@ -196,6 +263,16 @@ func (r *T128Transform) Init() error {
 			return (current - prev) / (t2.Sub(t1).Seconds()), true, nil
 		}
 	case "state-change":
+
+		if r.PersistTo != "" {
+			persistedCache, err := loadCache(r.PersistTo)
+			if err != nil {
+				r.Log.Warnf("unable to load cache from %s: %s", r.PersistTo, err)
+			} else {
+				r.cache = persistedCache
+			}
+		}
+
 		r.transform = func(expired bool, t1, t2 time.Time, v1, v2 interface{}) (interface{}, bool, error) {
 			if expired || v1 == nil {
 				return v2, true, nil
@@ -245,6 +322,36 @@ func (r *T128Transform) Init() error {
 		// If the time difference matches, don't expire. Adjusting here makes
 		// later math easier.
 		r.Expiration.Duration++
+	}
+
+	return nil
+}
+
+func loadCache(path string) (map[uint64]map[string]observedValue, error) {
+	cache := make(map[uint64]map[string]observedValue)
+
+	data, err := ioutil.ReadFile(path)
+    if err != nil {
+      return cache, err
+    }
+
+	err = json.Unmarshal(data, &cache)
+    if err != nil {
+        return cache, err
+    }
+
+	return cache, nil
+}
+
+func persistCache(path string, cache map[uint64]map[string]observedValue) error {
+	file, err := json.MarshalIndent(cache, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(path, file, 0644)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/plugins/processors/t128_transform/t128_transform.go
+++ b/plugins/processors/t128_transform/t128_transform.go
@@ -171,7 +171,7 @@ func (r *T128Transform) Apply(in ...telegraf.Metric) []telegraf.Metric {
 		}
 	}
 
-	if cacheChanged {
+	if r.PersistTo != "" && cacheChanged {
 		err := persistCache(r.PersistTo, r.cache)
 		if err != nil {
 			r.Log.Warnf("unable to persist cache to %s: %s", r.PersistTo, err)

--- a/plugins/processors/t128_transform/t128_transform_state_change_test.go
+++ b/plugins/processors/t128_transform/t128_transform_state_change_test.go
@@ -1,9 +1,9 @@
 package t128_transform
 
 import (
-	"path/filepath"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -379,7 +379,7 @@ func TestStateChangeWithPersistence(t *testing.T) {
 		t.Fatal(err)
 	}
 	persistenceFile.Close()
-	
+
 	t1 := time.Now()
 	r1 := newTranformWithPersistence(t, persistToPath)
 	m1 := newMetric("foo", nil, map[string]interface{}{"/state": "state1"}, t1)
@@ -406,4 +406,4 @@ func newTranformWithPersistence(t *testing.T, path string) *T128Transform {
 	assert.Nil(t, r.Init())
 
 	return r
-} 
+}

--- a/plugins/processors/t128_transform/t128_transform_state_change_test.go
+++ b/plugins/processors/t128_transform/t128_transform_state_change_test.go
@@ -380,30 +380,38 @@ func TestStateChangeWithPersistence(t *testing.T) {
 	}
 	persistenceFile.Close()
 
-	t1 := time.Now()
-	r1 := newTranformWithPersistence(t, persistToPath)
-	m1 := newMetric("foo", nil, map[string]interface{}{"/state": "state1"}, t1)
+	_, err = newTranformWithPersistence("diff", persistToPath)
+	assert.NotNil(t, err)
 
+	_, err = newTranformWithPersistence("rate", persistToPath)
+	assert.NotNil(t, err)
+
+	r1, err := newTranformWithPersistence("state-change", persistToPath)
+	assert.Nil(t, err)
+
+	t1 := time.Now()
+	m1 := newMetric("foo", nil, map[string]interface{}{"/state": "state1"}, t1)
 	rate1 := r1.Apply(m1)
 	assert.Len(t, rate1, 1)
 	assert.Equal(t, rate1[0].Fields(), sample{"/state": "state1"})
 
-	r2 := newTranformWithPersistence(t, persistToPath)
-	m2 := newMetric("foo", nil, map[string]interface{}{"/state": "state1"}, t1.Add(time.Duration(3)*time.Second))
+	r2, err := newTranformWithPersistence("state-change", persistToPath)
+	assert.Nil(t, err)
 
+	m2 := newMetric("foo", nil, map[string]interface{}{"/state": "state1"}, t1.Add(time.Duration(3)*time.Second))
 	rate2 := r2.Apply(m2)
 	assert.Len(t, rate2, 1)
 	assert.Equal(t, rate2[0].Fields(), sample{})
 }
 
-func newTranformWithPersistence(t *testing.T, path string) *T128Transform {
-	r := newTransformType("state-change")
+func newTranformWithPersistence(transformType string, path string) (*T128Transform, error) {
+	r := newTransformType(transformType)
 	r.Fields = map[string]string{"/state": "/state"}
 	r.RemoveOriginal = true
 	r.Expiration.Duration = 5 * time.Second
 	r.PersistTo = path
 	r.Log = models.NewLogger("test", "test", "")
-	assert.Nil(t, r.Init())
+	err := r.Init()
 
-	return r
+	return r, err
 }

--- a/plugins/processors/t128_transform/t128_transform_state_change_test.go
+++ b/plugins/processors/t128_transform/t128_transform_state_change_test.go
@@ -1,8 +1,13 @@
 package t128_transform
 
 import (
+	"path/filepath"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
+
+	"github.com/influxdata/telegraf/models"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -73,9 +78,9 @@ func TestStateChangeLeavesUnmarkedFieldsInTact(t *testing.T) {
 	assert.Equal(t, int64(60), v)
 }
 
-func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
-	type sample = map[string]interface{}
+type sample = map[string]interface{}
 
+func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 	testCases := []struct {
 		Name           string
 		Fields         map[string]string
@@ -359,3 +364,46 @@ func TestStateChangeRemoveOriginalAndRename(t *testing.T) {
 		})
 	}
 }
+
+func TestStateChangeWithPersistence(t *testing.T) {
+	testDir, err := ioutil.TempDir("/tmp/", "t128-transform-test")
+	if err != nil {
+		t.Fatalf("could not create temp dir: %v", testDir)
+	}
+	defer os.RemoveAll(testDir)
+
+	persistToPath := filepath.Join(testDir, "last-state")
+
+	persistenceFile, err := os.Create(persistToPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persistenceFile.Close()
+	
+	t1 := time.Now()
+	r1 := newTranformWithPersistence(t, persistToPath)
+	m1 := newMetric("foo", nil, map[string]interface{}{"/state": "state1"}, t1)
+
+	rate1 := r1.Apply(m1)
+	assert.Len(t, rate1, 1)
+	assert.Equal(t, rate1[0].Fields(), sample{"/state": "state1"})
+
+	r2 := newTranformWithPersistence(t, persistToPath)
+	m2 := newMetric("foo", nil, map[string]interface{}{"/state": "state1"}, t1.Add(time.Duration(3)*time.Second))
+
+	rate2 := r2.Apply(m2)
+	assert.Len(t, rate2, 1)
+	assert.Equal(t, rate2[0].Fields(), sample{})
+}
+
+func newTranformWithPersistence(t *testing.T, path string) *T128Transform {
+	r := newTransformType("state-change")
+	r.Fields = map[string]string{"/state": "/state"}
+	r.RemoveOriginal = true
+	r.Expiration.Duration = 5 * time.Second
+	r.PersistTo = path
+	r.Log = models.NewLogger("test", "test", "")
+	assert.Nil(t, r.Init())
+
+	return r
+} 


### PR DESCRIPTION
### Description
Persisting state will prevent duplicate metrics from being created

### Tesing
Unit
Manual

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
