### PR TITLE
Dont retry metric retrieval if configured endpoint is not found

### DIFF
--- a/plugins/inputs/t128_graphql/README.md
+++ b/plugins/inputs/t128_graphql/README.md
@@ -25,6 +25,9 @@ The graphql input plugin collects data from a 128T instance via graphQL.
 ## Amount of time allowed to complete a single HTTP request
 # timeout = "5s"
 
+## If false, the collector will continue querying when the graphQL server responds with 404 Not Found
+# retry_if_not_found = false
+
 ## Required. The fields to collect with the desired name as the key (left) and the graphQL 
 ## query path as the value (right). The path can be relative to the entry point or an absolute
 ## path that does not diverge from the entry-point and does not contain graphQL arguments such

--- a/plugins/inputs/t128_graphql/sample.go
+++ b/plugins/inputs/t128_graphql/sample.go
@@ -20,6 +20,9 @@ var sampleConfig = `
 ## Amount of time allowed to complete a single HTTP request
 # timeout = "5s"
 
+## If false, the collector will continue querying when the graphQL server responds with 404 Not Found
+# retry_if_not_found = false
+
 ## Required. The fields to collect with the desired name as the key (left) and the graphQL 
 ## query path as the value (right). The path can be relative to the entry point or an absolute
 ## path that does not diverge from the entry-point and does not contain graphQL arguments such

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -181,7 +181,7 @@ func (plugin *T128GraphQL) Gather(acc telegraf.Accumulator) error {
 		for _, err := range decodeAndReportJSONErrors(message, template) {
 			acc.AddError(err)
 
-			if strings.Contains(fmt.Sprintf("%s", err), "returned a 404") {
+			if strings.Contains(err.Error(), "returned a 404") {
 				plugin.endpointNotFound = true
 
 				if !plugin.RetryIfNotFound {

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -183,7 +183,7 @@ func (plugin *T128GraphQL) Gather(acc telegraf.Accumulator) error {
 
 			if strings.Contains(fmt.Sprintf("%s", err), "returned a 404") {
 				plugin.endpointNotFound = true
-	
+
 				if !plugin.RetryIfNotFound {
 					acc.AddError(errors.New("collector configured to not retry when endpoint not found (404), stopping queries"))
 				}

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -164,14 +164,6 @@ func (plugin *T128GraphQL) Gather(acc telegraf.Accumulator) error {
 		for _, err := range decodeAndReportJSONErrors(message, template) {
 			acc.AddError(err)
 		}
-
-		if response.StatusCode == 404 {
-			plugin.endpointNotFound = true
-
-			if !plugin.RetryIfNotFound {
-				acc.AddError(errors.New("collector configured to not retry when endpoint not found (404), stopping queries"))
-			}
-		}
 		return nil
 	}
 
@@ -188,6 +180,14 @@ func (plugin *T128GraphQL) Gather(acc telegraf.Accumulator) error {
 		template := fmt.Sprintf("unexpected response for collector %s", plugin.CollectorName) + ": %s"
 		for _, err := range decodeAndReportJSONErrors(message, template) {
 			acc.AddError(err)
+
+			if strings.Contains(fmt.Sprintf("%s", err), "returned a 404") {
+				plugin.endpointNotFound = true
+	
+				if !plugin.RetryIfNotFound {
+					acc.AddError(errors.New("collector configured to not retry when endpoint not found (404), stopping queries"))
+				}
+			}
 		}
 		return nil
 	}

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -25,18 +26,20 @@ const (
 
 //T128GraphQL is an input for metrics of a 128T router instance
 type T128GraphQL struct {
-	CollectorName string            `toml:"collector_name"`
-	BaseURL       string            `toml:"base_url"`
-	UnixSocket    string            `toml:"unix_socket"`
-	EntryPoint    string            `toml:"entry_point"`
-	Fields        map[string]string `toml:"extract_fields"`
-	Tags          map[string]string `toml:"extract_tags"`
-	Timeout       internal.Duration `toml:"timeout"`
+	CollectorName   string            `toml:"collector_name"`
+	BaseURL         string            `toml:"base_url"`
+	UnixSocket      string            `toml:"unix_socket"`
+	EntryPoint      string            `toml:"entry_point"`
+	Fields          map[string]string `toml:"extract_fields"`
+	Tags            map[string]string `toml:"extract_tags"`
+	Timeout         internal.Duration `toml:"timeout"`
+	RetryIfNotFound bool              `toml:"retry_if_not_found"`
 
-	Config      *Config
-	Query       string
-	requestBody []byte
-	client      *http.Client
+	Config           *Config
+	Query            string
+	requestBody      []byte
+	client           *http.Client
+	endpointNotFound bool
 }
 
 //SampleConfig returns the default configuration of the Input
@@ -103,6 +106,8 @@ func (plugin *T128GraphQL) Init() error {
 
 	plugin.client = &http.Client{Transport: transport, Timeout: plugin.Timeout.Duration}
 
+	plugin.endpointNotFound = false
+
 	return nil
 }
 
@@ -132,6 +137,10 @@ func (plugin *T128GraphQL) checkConfig() error {
 
 //Gather takes in an accumulator and adds the metrics that the Input gathers
 func (plugin *T128GraphQL) Gather(acc telegraf.Accumulator) error {
+	if !plugin.RetryIfNotFound && plugin.endpointNotFound {
+		return nil
+	}
+
 	request, err := plugin.createRequest()
 	if err != nil {
 		acc.AddError(fmt.Errorf("failed to create a request for query %s: %w", plugin.Query, err))
@@ -154,6 +163,14 @@ func (plugin *T128GraphQL) Gather(acc telegraf.Accumulator) error {
 		template := fmt.Sprintf("status code %d not OK for collector ", response.StatusCode) + plugin.CollectorName + ": %s"
 		for _, err := range decodeAndReportJSONErrors(message, template) {
 			acc.AddError(err)
+		}
+
+		if response.StatusCode == 404 {
+			plugin.endpointNotFound = true
+
+			if !plugin.RetryIfNotFound {
+				acc.AddError(errors.New("collector configured to not retry when endpoint not found (404), stopping queries"))
+			}
 		}
 		return nil
 	}

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -89,7 +89,7 @@ var CollectorTestCases = []struct {
 		ExpectedRequests: []int{1},
 	},
 	{
-		Name:            "retries if not found",
+		Name:            "propogates not found error to accumulator",
 		EntryPoint:      "allRouters(name:'not-a-router')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:          map[string]string{"test-field": "test-field"},
 		Tags:            map[string]string{"test-tag": "test-tag"},
@@ -98,25 +98,8 @@ var CollectorTestCases = []struct {
 		ExpectedMetrics: nil,
 		ExpectedErrors: []string{
 			"status code 404 not OK for collector test-collector: it's not right",
-			"status code 404 not OK for collector test-collector: it's not right",
 		},
-		RetryIfNotFound:  true,
-		ExpectedRequests: []int{1, 2},
-	},
-	{
-		Name:            "doesn't retry if not found",
-		EntryPoint:      "allRouters(name:'not-a-router')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
-		Fields:          map[string]string{"test-field": "test-field"},
-		Tags:            map[string]string{"test-tag": "test-tag"},
-		Query:           InvalidRouterQuery,
-		Endpoint:        Endpoint{"/api/v1/graphql/", 404, InvalidRouterExpectedRequest, `it's not right`},
-		ExpectedMetrics: nil,
-		ExpectedErrors: []string{
-			"status code 404 not OK for collector test-collector: it's not right",
-			"collector configured to not retry when endpoint not found (404), stopping queries",
-		},
-		RetryIfNotFound:  false,
-		ExpectedRequests: []int{1, 1},
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:             "propogates invalid json error to accumulator",
@@ -149,6 +132,48 @@ var CollectorTestCases = []struct {
 		ExpectedMetrics:  nil,
 		ExpectedErrors:   []string{"unexpected response for collector test-collector: Cannot query field \"invalid-field\" on type \"ArpEntryType\"."},
 		ExpectedRequests: []int{1},
+	},
+	{
+		Name:            "retries if not found",
+		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field": "test-field"},
+		Tags:       nil,
+		Query:      ValidQueryNoTag,
+		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestNoTag, `
+		{
+			"errors": [{
+				"name": "GraphQLError",
+				"message": "highwayManager@CHSSDWCond01CHI.CHSSDWCondMD returned a 404"
+			}]
+		  }`},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"unexpected response for collector test-collector: highwayManager@CHSSDWCond01CHI.CHSSDWCondMD returned a 404",
+			"unexpected response for collector test-collector: highwayManager@CHSSDWCond01CHI.CHSSDWCondMD returned a 404",
+		},
+		RetryIfNotFound:  true,
+		ExpectedRequests: []int{1, 2},
+	},
+	{
+		Name:            "doesn't retry if not found",
+		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
+		Fields:     map[string]string{"test-field": "test-field"},
+		Tags:       nil,
+		Query:      ValidQueryNoTag,
+		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestNoTag, `
+		{
+			"errors": [{
+				"name": "GraphQLError",
+				"message": "highwayManager@CHSSDWCond01CHI.CHSSDWCondMD returned a 404"
+			}]
+		  }`},
+		ExpectedMetrics: nil,
+		ExpectedErrors: []string{
+			"unexpected response for collector test-collector: highwayManager@CHSSDWCond01CHI.CHSSDWCondMD returned a 404",
+			"collector configured to not retry when endpoint not found (404), stopping queries",
+		},
+		RetryIfNotFound:  false,
+		ExpectedRequests: []int{1, 1},
 	},
 	{
 		Name:       "missing extract-tags produces response",

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -134,7 +134,7 @@ var CollectorTestCases = []struct {
 		ExpectedRequests: []int{1},
 	},
 	{
-		Name:            "retries if not found",
+		Name:       "retries if not found",
 		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:     map[string]string{"test-field": "test-field"},
 		Tags:       nil,
@@ -155,7 +155,7 @@ var CollectorTestCases = []struct {
 		ExpectedRequests: []int{1, 2},
 	},
 	{
-		Name:            "doesn't retry if not found",
+		Name:       "doesn't retry if not found",
 		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:     map[string]string{"test-field": "test-field"},
 		Tags:       nil,

--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -35,6 +36,7 @@ type T128Metrics struct {
 	client    *http.Client
 	limiter   *requestLimiter
 	retriever Retriever
+	notFoundMetrics  map[int]struct{}
 }
 
 // ConfiguredMetric represents a single configured metric element
@@ -127,6 +129,8 @@ func (plugin *T128Metrics) Init() error {
 		plugin.retriever = NewIndividualRetriever(plugin.UseIntegerConversion, plugin.ConfiguredMetrics)
 	}
 
+	plugin.notFoundMetrics = make(map[int]struct{}, 0)
+
 	return nil
 }
 
@@ -139,6 +143,11 @@ func (plugin *T128Metrics) Gather(acc telegraf.Accumulator) error {
 	wg.Add(plugin.retriever.RequestCount())
 
 	for index := 0; index < plugin.retriever.RequestCount(); index++ {
+		if _, ok := plugin.notFoundMetrics[index]; ok {
+			wg.Done()
+			continue
+		}
+		
 		go func(idx int) {
 			plugin.retrieveMetrics(idx, acc, timestamp)
 			wg.Done()
@@ -171,6 +180,12 @@ func (plugin *T128Metrics) retrieveMetrics(index int, acc telegraf.Accumulator, 
 		message, err := ioutil.ReadAll(response.Body)
 		if err != nil {
 			message = []byte("")
+		}
+
+		if strings.Contains(string(message), "No configured endpoints satisfy the request") {
+			acc.AddError(fmt.Errorf("no metric found for %s: will no longer retrieve", plugin.retriever.Describe(index)))
+			plugin.notFoundMetrics[index] = struct{}{}
+			return
 		}
 
 		acc.AddError(fmt.Errorf("status code %d not OK for %s: %s", response.StatusCode, plugin.retriever.Describe(index), message))

--- a/plugins/inputs/t128_metrics/t128_metrics.go
+++ b/plugins/inputs/t128_metrics/t128_metrics.go
@@ -33,10 +33,10 @@ type T128Metrics struct {
 	UseIntegerConversion    bool               `toml:"use_integer_conversion"`
 	UseBulkRetrieval        bool               `toml:"use_bulk_retrieval"`
 
-	client    *http.Client
-	limiter   *requestLimiter
-	retriever Retriever
-	notFoundMetrics  map[int]struct{}
+	client          *http.Client
+	limiter         *requestLimiter
+	retriever       Retriever
+	notFoundMetrics map[int]struct{}
 }
 
 // ConfiguredMetric represents a single configured metric element
@@ -147,7 +147,7 @@ func (plugin *T128Metrics) Gather(acc telegraf.Accumulator) error {
 			wg.Done()
 			continue
 		}
-		
+
 		go func(idx int) {
 			plugin.retrieveMetrics(idx, acc, timestamp)
 			wg.Done()

--- a/plugins/inputs/t128_metrics/t128_metrics_test.go
+++ b/plugins/inputs/t128_metrics/t128_metrics_test.go
@@ -31,6 +31,7 @@ var ResponseProcessingTestCases = []struct {
 	Endpoints         []Endpoint
 	ExpectedMetrics   []*testutil.Metric
 	ExpectedErrors    []string
+	ExpectedRequests  []int
 	IntegerConversion bool
 	BulkRetrieval     bool
 }{
@@ -40,6 +41,7 @@ var ResponseProcessingTestCases = []struct {
 		Endpoints:         []Endpoint{},
 		ExpectedMetrics:   nil,
 		ExpectedErrors:    nil,
+		ExpectedRequests:  []int{0},
 	},
 	{
 		Name:              "empty configured metrics produce no requests or metrics bulk",
@@ -48,6 +50,7 @@ var ResponseProcessingTestCases = []struct {
 		Endpoints:         []Endpoint{},
 		ExpectedMetrics:   nil,
 		ExpectedErrors:    nil,
+		ExpectedRequests:  []int{0},
 	},
 	{
 		Name: "empty results produce no metrics",
@@ -56,9 +59,10 @@ var ResponseProcessingTestCases = []struct {
 			map[string]string{"test-field": "stats/test"},
 			map[string][]string{},
 		}},
-		Endpoints:       []Endpoint{{"/stats/test", 200, "{}", "[]"}},
-		ExpectedMetrics: nil,
-		ExpectedErrors:  nil,
+		Endpoints:        []Endpoint{{"/stats/test", 200, "{}", "[]"}},
+		ExpectedMetrics:  nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:          "empty results produce no metrics bulk",
@@ -68,9 +72,10 @@ var ResponseProcessingTestCases = []struct {
 			map[string]string{"test-field": "stats/test"},
 			map[string][]string{},
 		}},
-		Endpoints:       []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, "[]"}},
-		ExpectedMetrics: nil,
-		ExpectedErrors:  nil,
+		Endpoints:        []Endpoint{{"/", 200, `{"ids": ["/stats/test"]}`, "[]"}},
+		ExpectedMetrics:  nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name: "none value produces no metric",
@@ -86,8 +91,9 @@ var ResponseProcessingTestCases = []struct {
 				"value": null
 			}]
 		}]`}},
-		ExpectedMetrics: nil,
-		ExpectedErrors:  nil,
+		ExpectedMetrics:  nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:          "none value produces no metric bulk",
@@ -104,8 +110,9 @@ var ResponseProcessingTestCases = []struct {
 				"value": null
 			}]
 		}]`}},
-		ExpectedMetrics: nil,
-		ExpectedErrors:  nil,
+		ExpectedMetrics:  nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name: "forms string value if it is non numeric",
@@ -128,7 +135,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": "test-string"},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:          "forms string value if it is non numeric bulk",
@@ -152,7 +160,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": "test-string"},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "forms float value if integer conversion is disabled",
@@ -176,7 +185,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 50.0},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "forms float value if integer conversion is disabled bulk",
@@ -201,7 +211,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 50.0},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "forms integer value if integer conversion is enabled",
@@ -225,7 +236,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 50},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "forms integer value if integer conversion is enabled bulk",
@@ -250,7 +262,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 50},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name: "forms float value if it is a float",
@@ -273,7 +286,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 50.5},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:          "forms float value if it is a float bulk",
@@ -297,7 +311,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 50.5},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "adds permutation parameters to metrics",
@@ -330,7 +345,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 0},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "adds permutation parameters to metrics bulk",
@@ -364,7 +380,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 0},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "produces multiple metrics for multiple permutations",
@@ -409,7 +426,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 306},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "produces multiple metrics for multiple permutations bulk",
@@ -455,7 +473,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"test-field": 306},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name:              "hits multiple endpoints",
@@ -495,7 +514,47 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"another-test-field": 60},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{2},
+	},
+	{
+		Name:              "stops retrieving if not found",
+		IntegerConversion: true,
+		ConfiguredMetrics: []plugin.ConfiguredMetric{{
+			"test-metric",
+			map[string]string{"test-field": "stats/test"},
+			map[string][]string{},
+		}, {
+			"another-test-metric",
+			map[string]string{"another-test-field": "stats/another/test"},
+			map[string][]string{},
+		}},
+		Endpoints: []Endpoint{{"/stats/test", 200, "{}", `[{
+			"id": "/stats/test-metric",
+			"permutations": [{
+				"parameters": [],
+				"value": "50"
+			}]
+		}]`}, {
+			"/stats/another/test", 400, "{}",
+			`{"message":"No configured endpoints satisfy the request: {[/stats/test-metric] map[]}"}`,
+		}},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+			{
+				Measurement: "test-metric",
+				Tags:        map[string]string{},
+				Fields:      map[string]interface{}{"test-field": 50},
+			},
+		},
+		ExpectedErrors: []string{
+			"no metric found for metric stats/another/test: will no longer retrieve",
+		},
+		ExpectedRequests: []int{2, 3},
 	},
 	{
 		Name:              "requests bulk in single request",
@@ -535,7 +594,8 @@ var ResponseProcessingTestCases = []struct {
 				Fields:      map[string]interface{}{"another-test-field": 60},
 			},
 		},
-		ExpectedErrors: nil,
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
 	},
 	{
 		Name: "propogates errors to accumulator",
@@ -563,6 +623,7 @@ var ResponseProcessingTestCases = []struct {
 			"status code 300 not OK for metric stats/300: it's not right",
 			"failed to decode response for metric stats/invalid-json: invalid character '}' looking for beginning of value",
 		},
+		ExpectedRequests: []int{3},
 	},
 	{
 		Name:              "mixes errors and valid results",
@@ -596,6 +657,7 @@ var ResponseProcessingTestCases = []struct {
 		ExpectedErrors: []string{
 			"status code 404 not OK for metric stats/404: it's not right",
 		},
+		ExpectedRequests: []int{2},
 	},
 }
 
@@ -722,7 +784,7 @@ var RequestFormationTestCases = []struct {
 func TestT128MetricsResponseProcessing(t *testing.T) {
 	for _, testCase := range ResponseProcessingTestCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			fakeServer := createTestServer(t, testCase.Endpoints)
+			fakeServer, requestCount := createTestServer(t, testCase.Endpoints)
 			defer fakeServer.Close()
 
 			plugin := &plugin.T128Metrics{
@@ -736,7 +798,20 @@ func TestT128MetricsResponseProcessing(t *testing.T) {
 			var acc testutil.Accumulator
 			require.NoError(t, plugin.Init())
 
-			plugin.Gather(&acc)
+			for _, expectedRequests := range testCase.ExpectedRequests {
+				plugin.Gather(&acc)
+				require.Equal(t, expectedRequests, *requestCount)
+
+				// Timestamps aren't important, but need to match
+				for _, m := range acc.Metrics {
+					m.Time = time.Time{}
+				}
+
+				// Avoid specifying this unused type for each field
+				for _, m := range testCase.ExpectedMetrics {
+					m.Type = telegraf.Untyped
+				}
+			}
 
 			var errorStrings []string = nil
 			for _, err := range acc.Errors {
@@ -744,17 +819,6 @@ func TestT128MetricsResponseProcessing(t *testing.T) {
 			}
 
 			require.ElementsMatch(t, testCase.ExpectedErrors, errorStrings)
-
-			// Timestamps aren't important, but need to match
-			for _, m := range acc.Metrics {
-				m.Time = time.Time{}
-			}
-
-			// Avoid specifying this unused type for each field
-			for _, m := range testCase.ExpectedMetrics {
-				m.Type = telegraf.Untyped
-			}
-
 			require.ElementsMatch(t, testCase.ExpectedMetrics, acc.Metrics)
 		})
 	}
@@ -763,7 +827,7 @@ func TestT128MetricsResponseProcessing(t *testing.T) {
 func TestT128MetricsRequestFormation(t *testing.T) {
 	for _, testCase := range RequestFormationTestCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			fakeServer := createTestServer(t, testCase.Endpoints)
+			fakeServer, _ := createTestServer(t, testCase.Endpoints)
 			defer fakeServer.Close()
 
 			plugin := &plugin.T128Metrics{
@@ -904,14 +968,16 @@ func TestLoadsFromToml(t *testing.T) {
 	require.True(t, plugin.UseBulkRetrieval)
 }
 
-func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
+func createTestServer(t *testing.T, e []Endpoint) (*httptest.Server, *int) {
 	endpoints := make(map[string]Endpoint)
 	for _, endpoint := range e {
 		endpoints[endpoint.URL] = endpoint
 	}
 
+	requestCount := 0
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
+		requestCount += 1
 
 		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		require.Equal(t, "POST", r.Method)
@@ -937,5 +1003,5 @@ func createTestServer(t *testing.T, e []Endpoint) *httptest.Server {
 		w.Write([]byte(endpoint.Response))
 	}))
 
-	return fakeServer
+	return fakeServer, &requestCount
 }


### PR DESCRIPTION
### Description
The continuous retry and failure was causing an conductor upgrade failure from 4.5.10 -> 5.1.7

### Testing
- [x] Verification that request retries stop
- [x] Upgrade test

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
