### PR TITLE
Add an encoding processor for encoding/decoding gzip in string fields

### DIFF
--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/processors/date"
 	_ "github.com/influxdata/telegraf/plugins/processors/dedup"
 	_ "github.com/influxdata/telegraf/plugins/processors/defaults"
+	_ "github.com/influxdata/telegraf/plugins/processors/encoding"
 	_ "github.com/influxdata/telegraf/plugins/processors/enum"
 	_ "github.com/influxdata/telegraf/plugins/processors/execd"
 	_ "github.com/influxdata/telegraf/plugins/processors/filepath"

--- a/plugins/processors/encoding/README.md
+++ b/plugins/processors/encoding/README.md
@@ -1,0 +1,39 @@
+# Encoding Processor
+
+The `encoding` processor provides compression/decompression of string fields along with conversion to/from relevant encodings that function with Influx and line protocol.
+
+## Configuration
+
+```toml
+[[processors.encoding]]
+  ## (required) Field specifies which string field to operate on
+  # field = ""
+
+  ## (required) Encoding is the algorithm used to encode the compressed binary
+  ## data into a string Influx can process. Only base64 is supported for now.
+  ## Because compression deals with binary data (not supported by Influx),
+  ## encoding is required. However, encoding may be used with no compression if
+  ## desired.
+  # encoding = "base64"
+
+  ## Destination field is the field where the encoding result will be stored.
+  ## If not specified, field is used.
+  # dest_field = ""
+
+  ## Whether the original field should be removed if it doesn't match dest_field.
+  # remove_original = false
+
+  ## Operation determines whether to "encode" or "decode"
+  # operation = "decode"
+
+  ## Compression describes the compression algorithm used for the field. If
+  ## empty, compression is skipped. Only gzip is supported for now. Compression
+  ## requires that an encoding be set as Influx does not support binary data.
+  # compression = "gzip"
+
+  ## Compression field and tag allow the compression algorithm to be retrieved
+  ## from a field or tag on a metric. Tag takes precedence over field. If
+  ## neither is found, "compression" (if any) is used for the metric.
+  # compression_field = ""
+  # compression_tag = ""
+```

--- a/plugins/processors/encoding/encoding.go
+++ b/plugins/processors/encoding/encoding.go
@@ -1,0 +1,210 @@
+package encoding
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/processors"
+)
+
+const sampleConfig = `
+[[processors.encoding]]
+  ## (required) Field specifies which string field to operate on
+  # field = ""
+
+  ## (required) Encoding is the algorithm used to encode the compressed binary
+  ## data into a string Influx can process. Only base64 is supported for now.
+  ## Because compression deals with binary data (not supported by Influx),
+  ## encoding is required. However, encoding may be used with no compression if
+  ## desired.
+  # encoding = "base64"
+
+  ## Destination field is the field where the encoding result will be stored.
+  ## If not specified, field is used.
+  # dest_field = ""
+
+  ## Whether the original field should be removed if it doesn't match dest_field.
+  # remove_original = false
+
+  ## Operation determines whether to "encode" or "decode"
+  # operation = "decode"
+
+  ## Compression describes the compression algorithm used for the field. If
+  ## empty, compression is skipped. Only gzip is supported for now. Compression
+  ## requires that an encoding be set as Influx does not support binary data.
+  # compression = "gzip"
+
+  ## Compression field and tag allow the compression algorithm to be retrieved
+  ## from a field or tag on a metric. Tag takes precedence over field. If
+  ## neither is found, "compression" (if any) is used for the metric.
+  # compression_field = ""
+  # compression_tag = ""
+`
+
+type Encoding struct {
+	Field            string `toml:"field"`
+	RemoveOriginal   bool   `toml:"remove_original"`
+	DestField        string `toml:"dest_field"`
+	Operation        string `toml:"operation"`
+	Compression      string `toml:"compression"`
+	CompressionField string `toml:"compression_field"`
+	CompressionTag   string `toml:"compression_tag"`
+	Encoding         string `toml:"encoding"`
+
+	Log       telegraf.Logger `toml:"-"`
+	operation func(string, string, string) (string, error)
+}
+
+func (e *Encoding) SampleConfig() string {
+	return sampleConfig
+}
+
+func (e *Encoding) Description() string {
+	return "Encodes or decodes data that may also have been compressed"
+}
+
+func (e *Encoding) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	for _, point := range in {
+		valueIntf, ok := point.GetField(e.Field)
+		if !ok {
+			continue
+		}
+
+		value, ok := valueIntf.(string)
+		if !ok {
+			e.Log.Warnf("skipping encoding because metric had non-string value for field %v: %v", e.Field, valueIntf)
+			continue
+		}
+
+		var compression string
+		var compressionFound bool
+
+		if e.CompressionTag != "" {
+			compression, compressionFound = point.GetTag(e.CompressionTag)
+		}
+
+		if !compressionFound && e.CompressionField != "" {
+			if field, ok := point.GetField(e.CompressionField); ok {
+				compression, compressionFound = field.(string)
+			}
+		}
+
+		if !compressionFound {
+			compression = e.Compression
+		}
+
+		newValue, err := e.operation(value, compression, e.Encoding)
+		if err != nil {
+			e.Log.Warnf("failed to %v a metric: %v", e.Operation, err)
+			continue
+		}
+
+		point.AddField(e.DestField, newValue)
+
+		if e.RemoveOriginal {
+			point.RemoveField(e.Field)
+		}
+	}
+
+	return in
+}
+
+func (e *Encoding) Init() error {
+	switch e.Compression {
+	case "gzip":
+	case "":
+	default:
+		return fmt.Errorf("'%v' is not a supported compression algorithm. It must be 'gzip' or '' to skip.", e.Compression)
+	}
+
+	switch e.Encoding {
+	case "base64":
+	case "":
+		return fmt.Errorf("'encoding' is required for the encoding processor.")
+	default:
+		return fmt.Errorf("'%v' is not a supported encoding. It must be 'base64'.", e.Encoding)
+	}
+
+	if e.DestField == "" {
+		e.DestField = e.Field
+	}
+
+	if e.DestField == e.Field {
+		e.RemoveOriginal = false
+	}
+
+	switch e.Operation {
+	case "encode":
+		e.operation = encode
+	case "decode":
+		e.operation = decode
+	default:
+		return fmt.Errorf("'%v' is not a supported operation. It must be one of 'encode' or 'decode'.", e.Operation)
+	}
+
+	return nil
+}
+
+func newEncoding() *Encoding {
+	return &Encoding{}
+}
+
+func init() {
+	processors.Add("encoding", func() telegraf.Processor {
+		return newEncoding()
+	})
+}
+
+func encode(value, compression, encoding string) (string, error) {
+	switch compression {
+	case "gzip":
+		var buf bytes.Buffer
+		zipper := gzip.NewWriter(&buf)
+		_, err := zipper.Write([]byte(value))
+		zipper.Close()
+		if err != nil {
+			return "", err
+		}
+		value = string(buf.Bytes())
+	}
+
+	switch encoding {
+	case "base64":
+		value = base64.RawStdEncoding.EncodeToString([]byte(value))
+	}
+
+	return value, nil
+}
+
+func decode(value, compression, encoding string) (string, error) {
+	switch encoding {
+	case "base64":
+		data, err := base64.RawStdEncoding.DecodeString(value)
+		if err != nil {
+			return "", err
+		}
+		value = string(data)
+	}
+
+	switch compression {
+	case "gzip":
+		unzip, err := gzip.NewReader(strings.NewReader(value))
+		if err != nil {
+			return "", err
+		}
+
+		data, err := ioutil.ReadAll(unzip)
+		if err != nil {
+			return "", err
+		}
+
+		value = string(data)
+	}
+
+	return value, nil
+}

--- a/plugins/processors/encoding/encoding_test.go
+++ b/plugins/processors/encoding/encoding_test.go
@@ -1,0 +1,592 @@
+package encoding
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncoding(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		compression string
+		encoding    string
+		result      string
+		err         string
+	}{
+		{
+			name:        "gzip empty actually isn't empty",
+			value:       "",
+			compression: "gzip",
+			encoding:    "base64",
+			result:      "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA",
+			err:         "",
+		},
+		{
+			name:        "base64 empty remains empty",
+			value:       "",
+			compression: "",
+			encoding:    "base64",
+			result:      "",
+			err:         "",
+		},
+		{
+			name:        "gzip works with encoding",
+			value:       "this is a test",
+			compression: "gzip",
+			encoding:    "base64",
+			result:      "H4sIAAAAAAAA/yrJyCxWyCxWSFQoSS0uAQQAAP//6uceDQ4AAAA",
+			err:         "",
+		},
+		{
+			name:        "encoding works without compression",
+			value:       "this is a test",
+			compression: "",
+			encoding:    "base64",
+			result:      "dGhpcyBpcyBhIHRlc3Q",
+			err:         "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, err := encode(testCase.value, testCase.compression, testCase.encoding)
+			if testCase.err != "" {
+				assert.EqualError(t, err, testCase.err)
+			}
+			assert.Equal(t, testCase.result, result)
+		})
+	}
+}
+
+func TestDecoding(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		compression string
+		encoding    string
+		result      string
+		err         string
+	}{
+		{
+			name:        "gzip unzips empty string",
+			value:       "H4sIAAAAAAAA/wEAAP//AAAAAAAAAAA",
+			compression: "gzip",
+			encoding:    "base64",
+			result:      "",
+			err:         "",
+		},
+		{
+			name:        "base64 empty remains empty",
+			value:       "",
+			compression: "",
+			encoding:    "base64",
+			result:      "",
+			err:         "",
+		},
+		{
+			name:        "gzip works with encoding",
+			value:       "H4sIAAAAAAAA/yrJyCxWyCxWSFQoSS0uAQQAAP//6uceDQ4AAAA",
+			compression: "gzip",
+			encoding:    "base64",
+			result:      "this is a test",
+			err:         "",
+		},
+		{
+			name:        "encoding works without compression",
+			value:       "dGhpcyBpcyBhIHRlc3Q",
+			compression: "",
+			encoding:    "base64",
+			result:      "this is a test",
+			err:         "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, err := decode(testCase.value, testCase.compression, testCase.encoding)
+			if testCase.err != "" {
+				assert.EqualError(t, err, testCase.err)
+			}
+			assert.Equal(t, testCase.result, result)
+		})
+	}
+}
+
+func TestInitialization(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        string
+		manipulate func(*Encoding)
+		validate   func(*Encoding) error
+	}{
+		{
+			name:       "valid combination works",
+			manipulate: func(e *Encoding) {},
+		},
+		{
+			name:       "invalid compression causes error",
+			manipulate: func(e *Encoding) { e.Compression = "invalid" },
+			err:        "'invalid' is not a supported compression algorithm. It must be 'gzip' or '' to skip.",
+		},
+		{
+			name:       "empty compression works",
+			manipulate: func(e *Encoding) { e.Compression = "" },
+		},
+		{
+			name:       "empty encoding causes error",
+			manipulate: func(e *Encoding) { e.Encoding = "" },
+			err:        "'encoding' is required for the encoding processor.",
+		},
+		{
+			name:       "invalid encoding causes error",
+			manipulate: func(e *Encoding) { e.Encoding = "invalid" },
+			err:        "'invalid' is not a supported encoding. It must be 'base64'.",
+		},
+		{
+			name:       "encode operation works",
+			manipulate: func(e *Encoding) { e.Operation = "encode" },
+		},
+		{
+			name:       "decode operation works",
+			manipulate: func(e *Encoding) { e.Operation = "decode" },
+		},
+		{
+			name:       "invalid operation causes error",
+			manipulate: func(e *Encoding) { e.Operation = "invalid" },
+			err:        "'invalid' is not a supported operation. It must be one of 'encode' or 'decode'.",
+		},
+		{
+			name:       "assigns dest field to source field if unspecified",
+			manipulate: func(e *Encoding) { e.DestField = "" },
+			validate: func(e *Encoding) error {
+				if e.DestField != "sample" {
+					return fmt.Errorf("the dest field should be set to the source field if it's missing")
+				}
+				if e.RemoveOriginal {
+					return fmt.Errorf("remove original shouldn't be true if the dest field is the source field")
+				}
+				return nil
+			},
+		},
+		{
+			name: "no remove original if dest and source fields are the same",
+			manipulate: func(e *Encoding) {
+				e.DestField = e.Field
+				e.RemoveOriginal = true
+			},
+			validate: func(e *Encoding) error {
+				if e.RemoveOriginal {
+					return fmt.Errorf("remove original shouldn't be true if the dest field is the source field")
+				}
+				return nil
+			},
+		},
+		{
+			name: "allows removal of original field",
+			manipulate: func(e *Encoding) {
+				e.RemoveOriginal = true
+			},
+			validate: func(e *Encoding) error {
+				if !e.RemoveOriginal {
+					return fmt.Errorf("remove of the original should be possible")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := &Encoding{
+				Field:          "sample",
+				RemoveOriginal: false,
+				DestField:      "new-sample",
+				Operation:      "encode",
+				Compression:    "gzip",
+				Encoding:       "base64",
+			}
+
+			if testCase.manipulate != nil {
+				testCase.manipulate(e)
+			}
+
+			err := e.Init()
+			if testCase.err != "" {
+				assert.EqualError(t, err, testCase.err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if testCase.validate != nil {
+				assert.NoError(t, testCase.validate(e))
+			}
+		})
+	}
+}
+
+var start time.Time = time.Now()
+
+func m() *metricBuilder {
+	return &metricBuilder{
+		measurement: "a",
+		tags:        make(map[string]string),
+		fields:      make(map[string]interface{}),
+		timestamp:   start,
+	}
+}
+
+type metricBuilder struct {
+	measurement string
+	tags        map[string]string
+	fields      map[string]interface{}
+	timestamp   time.Time
+}
+
+func (m *metricBuilder) tag(tagKey, tagValue string) *metricBuilder {
+	m.tags[tagKey] = tagValue
+	return m
+}
+
+func (m *metricBuilder) field(fieldKey string, fieldValue interface{}) *metricBuilder {
+	m.fields[fieldKey] = fieldValue
+	return m
+}
+
+func (m *metricBuilder) build() telegraf.Metric {
+	metric, err := metric.New(m.measurement, m.tags, m.fields, m.timestamp)
+	if err != nil {
+		panic(err.Error())
+	}
+	return metric
+}
+
+func TestEncodingMetrics(t *testing.T) {
+	tests := []struct {
+		name      string
+		metrics   []telegraf.Metric
+		encoded   []telegraf.Metric
+		configure func(e *Encoding)
+	}{
+		{
+			name: "compresses by compression",
+			metrics: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().field("sample", "H4sIAAAAAAAA/ypJLS5RKEvMKU0FBAAA//8rQd3sCgAAAA").build(),
+			},
+		},
+		{
+			name: "skips compression if missing",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+		},
+		{
+			name: "compresses by field",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+				e.CompressionField = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "test value").field("compression", "gzip").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().
+					field("compression", "gzip").
+					field("sample", "H4sIAAAAAAAA/ypJLS5RKEvMKU0FBAAA//8rQd3sCgAAAA").
+					build(),
+			},
+		},
+		{
+			name: "compresses by tag",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+				e.CompressionTag = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "test value").tag("compression", "gzip").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().
+					tag("compression", "gzip").
+					field("sample", "H4sIAAAAAAAA/ypJLS5RKEvMKU0FBAAA//8rQd3sCgAAAA").
+					build(),
+			},
+		},
+		{
+			name: "compresses by tag over field",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+				e.CompressionTag = "compression"
+				e.CompressionField = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().
+					tag("compression", "").
+					field("compression", "gzip").
+					field("sample", "test value").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().
+					tag("compression", "").
+					field("compression", "gzip").
+					field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+		},
+		{
+			name: "compresses by field over default",
+			configure: func(e *Encoding) {
+				e.Compression = "gzip"
+				e.CompressionField = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().
+					field("compression", "").
+					field("sample", "test value").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().
+					field("compression", "").
+					field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+		},
+		{
+			name: "removes original",
+			configure: func(e *Encoding) {
+				e.DestField = "target"
+				e.RemoveOriginal = true
+				e.Compression = ""
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().field("target", "dGVzdCB2YWx1ZQ").build(),
+			},
+		},
+		{
+			name: "leaves original",
+			configure: func(e *Encoding) {
+				e.DestField = "target"
+				e.RemoveOriginal = false
+				e.Compression = ""
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+			encoded: []telegraf.Metric{
+				m().field("sample", "test value").field("target", "dGVzdCB2YWx1ZQ").build(),
+			},
+		},
+		{
+			name: "leaves metric with non-string field",
+			metrics: []telegraf.Metric{
+				m().field("sample", 5).build(),
+			},
+			encoded: []telegraf.Metric{
+				m().field("sample", 5).build(),
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := &Encoding{
+				Field:       "sample",
+				Operation:   "encode",
+				Compression: "gzip",
+				Encoding:    "base64",
+				Log:         testutil.Logger{},
+			}
+
+			if testCase.configure != nil {
+				testCase.configure(e)
+			}
+
+			assert.NoError(t, e.Init())
+			results := e.Apply(testCase.metrics...)
+
+			testutil.RequireMetricsEqual(t, testCase.encoded, results)
+		})
+	}
+}
+
+func TestDecodingMetrics(t *testing.T) {
+	tests := []struct {
+		name      string
+		metrics   []telegraf.Metric
+		decoded   []telegraf.Metric
+		configure func(e *Encoding)
+	}{
+		{
+			name: "decompressed by compression",
+			metrics: []telegraf.Metric{
+				m().field("sample", "H4sIAAAAAAAA/ypJLS5RKEvMKU0FBAAA//8rQd3sCgAAAA").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+		},
+		{
+			name: "skips decompression if missing",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+		},
+		{
+			name: "decompresses by field",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+				e.CompressionField = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().
+					field("sample", "H4sIAAAAAAAA/ypJLS5RKEvMKU0FBAAA//8rQd3sCgAAAA").
+					field("compression", "gzip").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().field("compression", "gzip").field("sample", "test value").build(),
+			},
+		},
+		{
+			name: "decompresses by tag",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+				e.CompressionTag = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().
+					tag("compression", "gzip").
+					field("sample", "H4sIAAAAAAAA/ypJLS5RKEvMKU0FBAAA//8rQd3sCgAAAA").
+					build(),
+			},
+			decoded: []telegraf.Metric{
+				m().tag("compression", "gzip").field("sample", "test value").build(),
+			},
+		},
+		{
+			name: "decompresses by tag over field",
+			configure: func(e *Encoding) {
+				e.Compression = ""
+				e.CompressionTag = "compression"
+				e.CompressionField = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().
+					tag("compression", "").
+					field("compression", "gzip").
+					field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().
+					tag("compression", "").
+					field("compression", "gzip").
+					field("sample", "test value").build(),
+			},
+		},
+		{
+			name: "decompresses by field over default",
+			configure: func(e *Encoding) {
+				e.Compression = "gzip"
+				e.CompressionField = "compression"
+			},
+			metrics: []telegraf.Metric{
+				m().
+					field("compression", "").
+					field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().
+					field("compression", "").
+					field("sample", "test value").build(),
+			},
+		},
+		{
+			name: "removes original",
+			configure: func(e *Encoding) {
+				e.DestField = "target"
+				e.RemoveOriginal = true
+				e.Compression = ""
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().field("target", "test value").build(),
+			},
+		},
+		{
+			name: "leaves original",
+			configure: func(e *Encoding) {
+				e.DestField = "target"
+				e.RemoveOriginal = false
+				e.Compression = ""
+			},
+			metrics: []telegraf.Metric{
+				m().field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().field("sample", "dGVzdCB2YWx1ZQ").field("target", "test value").build(),
+			},
+		},
+		{
+			name: "leaves failed decode",
+			metrics: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().field("sample", "test value").build(),
+			},
+		},
+		{
+			name: "leaves failed decompression",
+			metrics: []telegraf.Metric{
+				m().field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+			decoded: []telegraf.Metric{
+				m().field("sample", "dGVzdCB2YWx1ZQ").build(),
+			},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			e := &Encoding{
+				Field:       "sample",
+				Operation:   "decode",
+				Compression: "gzip",
+				Encoding:    "base64",
+				Log:         testutil.Logger{},
+			}
+
+			if testCase.configure != nil {
+				testCase.configure(e)
+			}
+
+			assert.NoError(t, e.Init())
+			results := e.Apply(testCase.metrics...)
+
+			testutil.RequireMetricsEqual(t, testCase.decoded, results)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add a compression processor that allows a field to be compressed/decompressed to/from gzip and encoded/decoded using base64 encoding.

## Testing

- Unit tests