### PR TITLE
Graph collector deadline header v2

### DIFF
--- a/plugins/inputs/t128_graphql/README.md
+++ b/plugins/inputs/t128_graphql/README.md
@@ -28,10 +28,6 @@ The graphql input plugin collects data from a 128T instance via graphQL.
 ## If false, the collector will continue querying when the graphQL server responds with 404 Not Found
 # retry_if_not_found = false
 
-## Amount of time for graphQL server to collect and return data. After deadline, partial responses
-## are returned. Default is no deadline. Deadline must be at least 1 second less than timeout.
-# deadline = "0s"
-
 ## Required. The fields to collect with the desired name as the key (left) and the graphQL
 ## query path as the value (right). The path can be relative to the entry point or an absolute
 ## path that does not diverge from the entry-point and does not contain graphQL arguments such

--- a/plugins/inputs/t128_graphql/sample.go
+++ b/plugins/inputs/t128_graphql/sample.go
@@ -23,10 +23,6 @@ var sampleConfig = `
 ## If false, the collector will continue querying when the graphQL server responds with 404 Not Found
 # retry_if_not_found = false
 
-## Amount of time for graphQL server to collect and return data. After deadline, partial responses
-## are returned. Default is no deadline. Deadline must be at least 1 second less than timeout.
-# deadline = "0s"
-
 ## Required. The fields to collect with the desired name as the key (left) and the graphQL 
 ## query path as the value (right). The path can be relative to the entry point or an absolute
 ## path that does not diverge from the entry-point and does not contain graphQL arguments such

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -23,11 +23,8 @@ const (
 	//DefaultRequestTimeout is the request timeout if none is configured
 	DefaultRequestTimeout = 5 * time.Second
 
-	//DefaultDeadline is the time for the graphQL server to build the response. Default is no deadline.
-	DefaultDeadline = 0 * time.Second
-
-	//MinTimeoutDeadlineDiff is the minimum value of plugin.Timeout - plugin.Deadline
-	MinTimeoutDeadlineDiff = 1 * time.Second
+	//timeoutDeadlineDiff is the difference between plugin.Timeout and the request deadline header
+	timeoutDeadlineDiff = 1 * time.Second
 )
 
 //T128GraphQL is an input for metrics of a 128T router instance
@@ -40,7 +37,6 @@ type T128GraphQL struct {
 	Tags            map[string]string `toml:"extract_tags"`
 	Timeout         internal.Duration `toml:"timeout"`
 	RetryIfNotFound bool              `toml:"retry_if_not_found"`
-	Deadline        internal.Duration `toml:"deadline"`
 
 	Config           *Config
 	Query            string
@@ -139,17 +135,6 @@ func (plugin *T128GraphQL) checkConfig() error {
 		return fmt.Errorf("extract_fields is a required configuration field")
 	}
 
-	if plugin.Deadline.Duration != DefaultDeadline {
-		timeoutDeadlineDiff := plugin.Timeout.Duration.Seconds() - plugin.Deadline.Duration.Seconds()
-		if timeoutDeadlineDiff < MinTimeoutDeadlineDiff.Seconds() {
-			return fmt.Errorf(
-				"timeout must be at least %d seconds greater than deadline: currently %d seconds greater",
-				int(MinTimeoutDeadlineDiff.Seconds()),
-				int(timeoutDeadlineDiff),
-			)
-		}
-	}
-
 	return nil
 }
 
@@ -240,10 +225,9 @@ func (plugin *T128GraphQL) createRequest() (*http.Request, error) {
 
 	request.Header.Add("Content-Type", "application/json")
 
-	if plugin.Deadline.Duration != DefaultDeadline {
-		deadline := int(plugin.Deadline.Duration.Truncate(time.Second))
-		request.Header.Add("deadline", fmt.Sprintf("%d", deadline))
-	}
+	// ignored in older versions of 128T
+	deadline := int(plugin.Timeout.Duration.Seconds() - timeoutDeadlineDiff.Seconds())
+	request.Header.Add("deadline", fmt.Sprintf("%d", deadline))
 
 	return request, nil
 }
@@ -308,8 +292,7 @@ func validateAndSeparatePaths(data map[string]string, entryPoint string) (map[st
 func init() {
 	inputs.Add("t128_graphql", func() telegraf.Input {
 		return &T128GraphQL{
-			Timeout:  internal.Duration{Duration: DefaultRequestTimeout},
-			Deadline: internal.Duration{Duration: DefaultDeadline},
+			Timeout: internal.Duration{Duration: DefaultRequestTimeout},
 		}
 	})
 }

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -48,8 +48,6 @@ var CollectorTestCases = []struct {
 	InitError        bool
 	Query            string
 	Endpoint         Endpoint
-	Timeout          internal.Duration
-	Deadline         internal.Duration
 	ExpectedMetrics  []*testutil.Metric
 	ExpectedErrors   []string
 	RetryIfNotFound  bool
@@ -68,16 +66,6 @@ var CollectorTestCases = []struct {
 		EntryPoint:       "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:           nil,
 		Tags:             nil,
-		InitError:        true,
-		ExpectedRequests: []int{0},
-	},
-	{
-		Name:             "fails init if deadline is too close to timeout",
-		EntryPoint:       "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
-		Fields:           map[string]string{"test-field": "test-field"},
-		Tags:             map[string]string{"test-tag": "test-tag"},
-		Timeout:          internal.Duration{Duration: time.Second * 5},
-		Deadline:         internal.Duration{Duration: time.Second * 7},
 		InitError:        true,
 		ExpectedRequests: []int{0},
 	},
@@ -276,9 +264,7 @@ var CollectorTestCases = []struct {
 			"test-tag":       "test-tag",
 			"other-test-tag": "allRouters/nodes/name",
 		},
-		Deadline: internal.Duration{Duration: time.Second * 5},
-		Timeout:  internal.Duration{Duration: time.Second * 10},
-		Query:    ValidQueryWithAbsPaths,
+		Query: ValidQueryWithAbsPaths,
 		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestWithAbsPaths, `{
 			"data": {
 				"allRouters": {
@@ -401,8 +387,7 @@ var CollectorTestCases = []struct {
 func TestT128GraphqlCollector(t *testing.T) {
 	for _, testCase := range CollectorTestCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			hasDeadline := testCase.Deadline.Duration != 0
-			fakeServer, requestCount := createTestServer(t, testCase.Endpoint, hasDeadline)
+			fakeServer, requestCount := createTestServer(t, testCase.Endpoint)
 			defer fakeServer.Close()
 
 			plugin := &plugin.T128GraphQL{
@@ -412,14 +397,6 @@ func TestT128GraphqlCollector(t *testing.T) {
 				Fields:          testCase.Fields,
 				Tags:            testCase.Tags,
 				RetryIfNotFound: testCase.RetryIfNotFound,
-			}
-
-			if testCase.Timeout.Duration != 0 {
-				plugin.Timeout = testCase.Timeout
-			}
-
-			if hasDeadline {
-				plugin.Deadline = testCase.Deadline
 			}
 
 			var acc testutil.Accumulator
@@ -495,18 +472,14 @@ func TestTimoutUsedForRequests(t *testing.T) {
 	fakeServer.Close()
 }
 
-func createTestServer(t *testing.T, endpoint Endpoint, hasDeadline bool) (*httptest.Server, *int) {
+func createTestServer(t *testing.T, endpoint Endpoint) (*httptest.Server, *int) {
 	requestCount := 0
 	fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		requestCount += 1
 
 		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
-		if hasDeadline {
-			require.NotEqual(t, r.Header.Get("deadline"), "")
-		} else {
-			require.Equal(t, r.Header.Get("deadline"), "")
-		}
+		require.NotEqual(t, r.Header.Get("deadline"), "")
 		require.Equal(t, "POST", r.Method)
 
 		if endpoint.URL != r.URL.Path {


### PR DESCRIPTION
### Description
The deadline header will be ignored in older versions of 128T so a new config knob doesn't need to be exposed.

### Testing
Unit

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
