### PR TITLE
Allow durations to use the `d` unit for day durations

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -41,11 +41,15 @@ func (d *Duration) UnmarshalTOML(b []byte) error {
 	if durStr == "" {
 		durStr = "0s"
 	}
-	// special case: logging interval had a default of 0d, which silently
-	// failed, but in order to prevent issues with default configs that had
-	// uncommented the option, change it from zero days to zero hours.
-	if durStr == "0d" {
-		durStr = "0h"
+
+	// parse day durations
+	if strings.HasSuffix(durStr, "d") {
+		dI, err := strconv.ParseInt(durStr[0:len(durStr)-1], 10, 64)
+		if err == nil {
+			dur := time.Duration(dI) * time.Duration(24) * time.Hour
+			*d = Duration(dur)
+			return nil
+		}
 	}
 
 	dur, err := time.ParseDuration(durStr)

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -60,6 +60,10 @@ func TestDuration(t *testing.T) {
 	require.NoError(t, d.UnmarshalTOML([]byte(`""`)))
 	require.Equal(t, 0*time.Second, time.Duration(d))
 
+	d = config.Duration(0)
+	require.NoError(t, d.UnmarshalTOML([]byte(`"2d"`)))
+	require.Equal(t, 48*time.Hour, time.Duration(d))
+
 	require.Error(t, d.UnmarshalTOML([]byte(`"1"`)))  // string missing unit
 	require.Error(t, d.UnmarshalTOML([]byte(`'2'`)))  // string missing unit
 	require.Error(t, d.UnmarshalTOML([]byte(`'ns'`))) // string missing time


### PR DESCRIPTION
## Description

There are cases where having durations in days is useful. In our particular case, the `128ext:duration` allows `d` as a unit and that extension is being used for durations within the plugin. It's a lot simpler to handle that unit rather than try to translate somewhere along the line.

## Testing

- [x] Unit
