### PR TITLE
Added a new Telegraf input for events and session-records (t128_tank)

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -194,6 +194,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/t128_graphql"
 	_ "github.com/influxdata/telegraf/plugins/inputs/t128_metrics"
 	_ "github.com/influxdata/telegraf/plugins/inputs/t128_peer_path"
+	_ "github.com/influxdata/telegraf/plugins/inputs/t128_tank"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tail"
 	_ "github.com/influxdata/telegraf/plugins/inputs/tcp_listener"
 	_ "github.com/influxdata/telegraf/plugins/inputs/teamspeak"

--- a/plugins/inputs/t128_tank/README.md
+++ b/plugins/inputs/t128_tank/README.md
@@ -6,18 +6,16 @@ The tank input plugin collects data from a 128T.
 
 ```toml
 [[inputs.t128_tank]]
-## A name for the collector which will be used as the measurement name of the produced data.
-# collector_name = "event_collector"
-
-## Required. A path for index file.
+## A (unique) file to use for index tracking. 
+## This tracking allows each event to be produced once.
 # index_file = ""
 
-## Required. Type of topic.
+## Required. The TANK topic to consume.
 # topic = "events"
 
-## Required. Port Number to get tank data from.
+## Port Number to get tank data from.
 # port_number = 11011
 
-## Required. Port Address to get tank data from.
-# port_address = "127.0.0.1"
+## Server Address to get tank data from.
+# server_address = "127.0.0.1"
 ```

--- a/plugins/inputs/t128_tank/README.md
+++ b/plugins/inputs/t128_tank/README.md
@@ -1,0 +1,23 @@
+# 128T TANK Input Plugin
+
+The tank input plugin collects data from a 128T.
+
+## Configuration
+
+```toml
+[[inputs.t128_tank]]
+## A name for the collector which will be used as the measurement name of the produced data.
+# collector_name = "event_collector"
+
+## Required. A path for index file.
+# index_file = ""
+
+## Required. Type of topic.
+# topic = "events"
+
+## Required. Port Number to get tank data from.
+# port_number = 11011
+
+## Required. Port Address to get tank data from.
+# port_address = "127.0.0.1"
+```

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"os"
 	"os/exec"
@@ -101,13 +100,11 @@ type Reader struct {
 	defaultIndex index
 	// telegraf Logger
 	log telegraf.Logger
-	// context in which go routine is executing
-	ctx context.Context
 	// telegraf accumulator
 	acc telegraf.Accumulator
 }
 
-func NewReader(tankAddress string, tankPort int, topic string, indexPath string, defaultIndex index, log telegraf.Logger, ctx context.Context, acc telegraf.Accumulator) *Reader {
+func NewReader(tankAddress string, tankPort int, topic string, indexPath string, defaultIndex index, log telegraf.Logger, acc telegraf.Accumulator) *Reader {
 	return &Reader{
 		topic:          topic,
 		tankReadCmdCtx: exec.CommandContext,
@@ -119,7 +116,6 @@ func NewReader(tankAddress string, tankPort int, topic string, indexPath string,
 		indexPath:      indexPath,
 		defaultIndex:   defaultIndex,
 		log:            log,
-		ctx:            ctx,
 		acc:            acc,
 	}
 }
@@ -129,9 +125,9 @@ func (r *Reader) withTankReadCommandContext(tankReadCmdCtx CommandContext) *Read
 	return r
 }
 
-func (r *Reader) Run() {
-	readCtx, readCtxCancel := context.WithCancel(r.ctx)
-	lastIndex, err := getIndex(r.indexPath, r.defaultIndex)
+func (r *Reader) Run(mainCtx context.Context) {
+	readCtx, readCtxCancel := context.WithCancel(mainCtx)
+	lastIndex, err := r.getIndex(r.indexPath, r.defaultIndex)
 	r.lastSavedIndex = lastIndex.value
 	if err != nil {
 		r.log.Errorf("Error in get index")
@@ -142,19 +138,19 @@ func (r *Reader) Run() {
 	nextSaveCheck := time.After(2 * time.Second)
 	defer func() {
 		readCtxCancel()
-		setIndex(r.indexPath, index{value: r.lastSavedIndex})
+		r.setIndex(r.indexPath, index{value: r.lastSavedIndex})
 	}()
 
-	go r.read(r.ctx, readCtx, lastIndex.next())
+	go r.read(mainCtx, readCtx, lastIndex.next())
 
 	for {
 		select {
-		case <-r.ctx.Done():
+		case <-mainCtx.Done():
 			r.log.Errorf("%s reader done", r.topic)
 			return
 		case <-nextSaveCheck:
 			if lastIndex.value > r.lastSavedIndex {
-				setIndex(r.indexPath, lastIndex)
+				r.setIndex(r.indexPath, lastIndex)
 				r.lastSavedIndex = lastIndex.value
 			}
 			nextSaveCheck = time.After(2 * time.Second)
@@ -319,21 +315,21 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 	}
 }
 
-func getIndex(indexPath string, defaultIndex index) (index, error) {
+func (r *Reader) getIndex(indexPath string, defaultIndex index) (index, error) {
 	if indexPath == "" {
-		log.Printf("index file path not provided, starting with default index %s", defaultIndex.string())
+		r.log.Debugf("index file path not provided, starting with default index %s", defaultIndex.string())
 		return defaultIndex, nil
 	}
 	content, err := os.ReadFile(indexPath)
 	if errors.Is(err, os.ErrNotExist) {
-		log.Printf("index file %s does not exist, starting with default index %s", indexPath, defaultIndex.string())
+		r.log.Debugf("index file %s does not exist, starting with default index %s", indexPath, defaultIndex.string())
 		return defaultIndex, nil
 
 	} else if err != nil {
 		return defaultIndex, fmt.Errorf("encountered error reading index file, starting with default index %s: %s", defaultIndex.string(), err)
 	}
 
-	log.Printf("found '%s' in index file", content)
+	r.log.Debugf("found '%s' in index file", content)
 
 	index, err := newIndex(string(content))
 	if err != nil {
@@ -343,22 +339,22 @@ func getIndex(indexPath string, defaultIndex index) (index, error) {
 	return index, nil
 }
 
-func setIndex(indexPath string, index index) {
+func (r *Reader) setIndex(indexPath string, index index) {
 	if indexPath == "" {
-		log.Printf("index file path not provided, starting with index %d", index.value)
+		r.log.Debugf("index file path not provided, starting with index %d", index.value)
 		return
 	}
 	_, err := os.Stat(path.Dir(indexPath))
 	if errors.Is(err, os.ErrNotExist) {
 		err := os.MkdirAll(path.Dir(indexPath), os.ModePerm)
 		if err != nil {
-			log.Printf("unable to create index file parent directory: %s", err)
+			r.log.Debugf("unable to create index file parent directory: %s", err)
 			return
 		}
 	}
 
 	err = os.WriteFile(indexPath, []byte(index.string()), 0644)
 	if err != nil {
-		log.Printf("unable to update index to %d: %s", index, err)
+		r.log.Debugf("unable to update index to %d: %s", index, err)
 	}
 }

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -141,7 +141,7 @@ func (r *Reader) Run(mainCtx context.Context) {
 		r.setIndex(r.indexPath, index{value: r.lastSavedIndex})
 	}()
 
-	go r.read(mainCtx, readCtx, lastIndex.next())
+	go r.read(readCtx, lastIndex.next())
 
 	for {
 		select {
@@ -158,9 +158,9 @@ func (r *Reader) Run(mainCtx context.Context) {
 			var errBoundaryFault *boundaryFault
 			if err != nil && errors.As(err, &errBoundaryFault) {
 				r.log.Debugf("detected boundary fault, restarting %s tank read from index %d", r.topic, errBoundaryFault.nextAvailableIndex.value)
-				go r.read(mainCtx, readCtx, errBoundaryFault.nextAvailableIndex)
+				go r.read(readCtx, errBoundaryFault.nextAvailableIndex)
 			} else {
-				go r.read(mainCtx, readCtx, lastIndex.next())
+				go r.read(readCtx, lastIndex.next())
 			}
 		}
 	}
@@ -204,20 +204,20 @@ func (r *Reader) setIndex(indexPath string, index index) {
 		}
 	}
 
-	err = os.WriteFile(indexPath, []byte(index.string()), 0644)
+	err = os.WriteFile(indexPath, []byte(index.string()), 0600)
 	if err != nil {
 		r.log.Debugf("unable to update index to %d: %s", index, err)
 	}
 }
 
-func (r *Reader) read(mainCtx context.Context, readCtx context.Context, startingIndex index) {
+func (r *Reader) read(readCtx context.Context, startingIndex index) {
 	r.log.Errorf("starting %s tank read from index %d", r.topic, startingIndex.value)
 	err := r.readFromTank(readCtx, startingIndex)
 	if err != nil {
 		r.log.Errorf("%s read routine exited with error: %v", r.topic, err)
 	}
 
-	if mainCtx.Err() == nil {
+	if readCtx.Err() == nil {
 		time.Sleep(r.restartDelay)
 	}
 
@@ -245,8 +245,11 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 
 	tankReader := bufio.NewReader(stdout)
 	if err := cmd.Start(); err != nil {
+		r.log.Errorf("Error starting command: %s", err.Error())
 		return fmt.Errorf("unable to start %s tank stream: %w", r.topic, err)
 	}
+
+	r.log.Infof("Command started successfully")
 
 	var parseErr error
 	var messages []*IndexedMessage
@@ -266,9 +269,7 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 		}
 		var collectedMessages []IndexedMessage
 		for _, message := range messages {
-			if message.IsValid() {
-				collectedMessages = append(collectedMessages, *message)
-			}
+			collectedMessages = append(collectedMessages, *message)
 		}
 		select {
 		case <-readCtx.Done():
@@ -299,25 +300,30 @@ func parseLines(tankReader *bufio.Reader, topic string) (messages []*IndexedMess
 			continue
 		}
 		message, err := ParseTankLine(rawLine)
+
 		if err != nil {
 			fmt.Errorf("parse failure for topic %s: %v", topic, err)
 			continue
 		}
 
 		if message == nil {
-			if isBoundaryFault, nextAvailabelIndex := isBoundaryFault(line); isBoundaryFault {
+			if isBoundaryFault, nextAvailableIndex := isBoundaryFault(line); isBoundaryFault {
 				return messages, fmt.Errorf(
 					"parsed boundary fault: %w",
-					&boundaryFault{nextAvailableIndex: nextAvailabelIndex},
+					&boundaryFault{nextAvailableIndex: nextAvailableIndex},
 				)
 			}
 
 			fmt.Errorf("skipping %s line because regex matching failed: %s", topic, line)
 			continue
 		}
+		if message != nil && message.IsValid() {
+			message.Message = bytes.TrimRight(message.Message, "\n")
+			messages = append(messages, message)
+		} else {
+			return nil, fmt.Errorf("invalid message received : %s", line)
+		}
 
-		message.Message = bytes.TrimRight(message.Message, "\n")
-		messages = append(messages, message)
 	}
 
 	return messages, err

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/influxdata/telegraf"
 )
 
 const (
@@ -29,7 +31,8 @@ var (
 	StartIndex         = index{value: startIndexUint}
 	EndIndex           = index{value: endIndexUint}
 	boundaryFaultRegex = regexp.MustCompile(`^Boundary Check fault. first available sequence number is (\d+), .*$`)
-	indexRegex         = regexp.MustCompile(`seq=(\d+?):(.*)$`)
+	sequenceStr        = []byte("seq=")
+	colonStr           = []byte(":")
 )
 
 type boundaryFault struct {
@@ -40,7 +43,6 @@ func (bf *boundaryFault) Error() string {
 	return fmt.Sprintf("next available index is %d", bf.nextAvailableIndex.value)
 }
 
-// InfluxLine
 type IndexedMessage struct {
 	Message   []byte
 	Index     index
@@ -82,7 +84,7 @@ type Reader struct {
 	topic          string
 	lastSavedIndex uint64
 	// used to send events from the read routine to the send routine
-	sendChan chan IndexedMessage
+	sendChan chan []IndexedMessage
 	// the target address for the TANK instance
 	tankAddress string
 	// the target port for the TANK instance
@@ -97,19 +99,28 @@ type Reader struct {
 	indexPath string
 	// default index in case reading to/from the index file fails
 	defaultIndex index
+	// telegraf Logger
+	log telegraf.Logger
+	// context in which go routine is executing
+	ctx context.Context
+	// telegraf accumulator
+	acc telegraf.Accumulator
 }
 
-func NewReader(tankAddress string, tankPort int, topic string, indexPath string, defaultIndex index) *Reader {
+func NewReader(tankAddress string, tankPort int, topic string, indexPath string, defaultIndex index, log telegraf.Logger, ctx context.Context, acc telegraf.Accumulator) *Reader {
 	return &Reader{
 		topic:          topic,
 		tankReadCmdCtx: exec.CommandContext,
-		sendChan:       make(chan IndexedMessage),
+		sendChan:       make(chan []IndexedMessage),
 		readDone:       make(chan error),
 		restartDelay:   5 * time.Second,
 		tankAddress:    tankAddress,
 		tankPort:       tankPort,
 		indexPath:      indexPath,
 		defaultIndex:   defaultIndex,
+		log:            log,
+		ctx:            ctx,
+		acc:            acc,
 	}
 }
 
@@ -118,13 +129,13 @@ func (r *Reader) withTankReadCommandContext(tankReadCmdCtx CommandContext) *Read
 	return r
 }
 
-func (r *Reader) Run(mainCtx context.Context, stopchan chan struct{}) {
-	readCtx, readCtxCancel := context.WithCancel(mainCtx)
-	paused := false
+func (r *Reader) Run() {
+	readCtx, readCtxCancel := context.WithCancel(r.ctx)
 	lastIndex, err := getIndex(r.indexPath, r.defaultIndex)
 	r.lastSavedIndex = lastIndex.value
 	if err != nil {
-		log.Printf("Error in get index")
+		r.log.Errorf("Error in get index")
+		readCtxCancel()
 		return
 	}
 
@@ -134,13 +145,12 @@ func (r *Reader) Run(mainCtx context.Context, stopchan chan struct{}) {
 		setIndex(r.indexPath, index{value: r.lastSavedIndex})
 	}()
 
-	go r.read(mainCtx, readCtx, lastIndex.next())
+	go r.read(r.ctx, readCtx, lastIndex.next())
 
 	for {
 		select {
-		case <-mainCtx.Done():
-			fmt.Printf("%s reader done", r.topic)
-			readCtxCancel()
+		case <-r.ctx.Done():
+			r.log.Errorf("%s reader done", r.topic)
 			return
 		case <-nextSaveCheck:
 			if lastIndex.value > r.lastSavedIndex {
@@ -148,28 +158,15 @@ func (r *Reader) Run(mainCtx context.Context, stopchan chan struct{}) {
 				r.lastSavedIndex = lastIndex.value
 			}
 			nextSaveCheck = time.After(2 * time.Second)
-		case err := <-r.readDone:
-			if !paused {
-				readCtx, readCtxCancel = context.WithCancel(mainCtx)
-				var boundaryFault *boundaryFault
-				if err != nil && errors.As(err, &boundaryFault) {
-					fmt.Printf("detected boundary fault, restarting %s tank read from index %d", r.topic, boundaryFault.nextAvailableIndex.value)
-					go r.read(mainCtx, readCtx, boundaryFault.nextAvailableIndex)
-				} else {
-					go r.read(mainCtx, readCtx, lastIndex.next())
-				}
-			} else {
-				fmt.Printf("reader is paused, skipping %s tank read restart", r.topic)
-			}
 		}
 	}
 }
 
 func (r *Reader) read(mainCtx context.Context, readCtx context.Context, startingIndex index) {
-	fmt.Printf("starting %s tank read from index %d", r.topic, startingIndex.value)
+	r.log.Errorf("starting %s tank read from index %d", r.topic, startingIndex.value)
 	err := r.readFromTank(readCtx, startingIndex)
 	if err != nil {
-		fmt.Printf("%s read routine exited with error: %v", r.topic, err)
+		r.log.Errorf("%s read routine exited with error: %v", r.topic, err)
 	}
 
 	if mainCtx.Err() == nil {
@@ -207,7 +204,7 @@ func parseLines(tankReader *bufio.Reader, topic string) (messages []*IndexedMess
 		}
 		message, err := ParseTankLine(rawLine)
 		if err != nil {
-			fmt.Printf("parse failure for topic %s: %v", topic, err)
+			fmt.Errorf("parse failure for topic %s: %v", topic, err)
 			continue
 		}
 
@@ -219,7 +216,7 @@ func parseLines(tankReader *bufio.Reader, topic string) (messages []*IndexedMess
 				)
 			}
 
-			fmt.Printf("skipping %s line because regex matching failed: %s", topic, line)
+			fmt.Errorf("skipping %s line because regex matching failed: %s", topic, line)
 			continue
 		}
 
@@ -231,19 +228,24 @@ func parseLines(tankReader *bufio.Reader, topic string) (messages []*IndexedMess
 }
 
 func ParseTankLine(line []byte) (*IndexedMessage, error) {
-	matches := indexRegex.FindSubmatch(line)
-	if len(matches) != 3 {
-		return nil, errors.New("invalid line format")
+	if !bytes.HasPrefix(line, sequenceStr) {
+		return nil, nil
 	}
 
-	index, err := newIndex(string(matches[1]))
+	colonIdx := bytes.Index(line, colonStr)
+	if colonIdx < 5 {
+		return nil, nil
+	}
+
+	indexBytes := line[4:colonIdx]
+
+	index, err := newIndex(string(indexBytes))
 	if err != nil {
-		return nil, fmt.Errorf("unable to parse index %s, skipping: %s", matches[1], err)
+		return nil, fmt.Errorf("unable to parse index %s, skipping: %s", indexBytes, err)
 	}
 
-	message := matches[2]
 	return &IndexedMessage{
-		Message: message,
+		Message: line[colonIdx+1:],
 		Index:   index,
 	}, nil
 }
@@ -256,7 +258,7 @@ func isBoundaryFault(line string) (bool, index) {
 
 	nextIndex, err := newIndex(matches[1])
 	if err != nil {
-		fmt.Printf("unable to parse index after detecting boundary fault: %s", err)
+		fmt.Errorf("unable to parse index after detecting boundary fault: %s", err)
 		return false, StartIndex
 	}
 
@@ -283,7 +285,6 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 	}
 
 	tankReader := bufio.NewReader(stdout)
-
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("unable to start %s tank stream: %w", r.topic, err)
 	}
@@ -294,30 +295,35 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 	for {
 		select {
 		case <-readCtx.Done():
-			fmt.Printf("%s read routine done", r.topic)
+			r.log.Errorf("%s read routine done", r.topic)
 			return nil
 		default:
 		}
 
 		messages, parseErr = parseLines(tankReader, r.topic)
 		if parseErr != nil {
-			fmt.Printf("encountered error while parsing lines in %s output, will not attempt to parse more lines: %v", r.topic, parseErr)
+			r.log.Errorf("encountered error while parsing lines in %s output, will not attempt to parse more lines: %v", r.topic, parseErr)
 			return parseErr
 		}
-		fmt.Println("After Parse Line inside read from tank")
+		var collectedMessages []IndexedMessage
 		for _, message := range messages {
 			if message.IsValid() {
-				select {
-				case <-readCtx.Done():
-					return nil
-				case r.sendChan <- *message:
-				}
+				collectedMessages = append(collectedMessages, *message)
 			}
+		}
+		select {
+		case <-readCtx.Done():
+			return nil
+		case r.sendChan <- collectedMessages:
 		}
 	}
 }
 
 func getIndex(indexPath string, defaultIndex index) (index, error) {
+	if indexPath == "" {
+		log.Printf("index file path not provided, starting with default index %s", defaultIndex.string())
+		return defaultIndex, nil
+	}
 	content, err := os.ReadFile(indexPath)
 	if errors.Is(err, os.ErrNotExist) {
 		log.Printf("index file %s does not exist, starting with default index %s", indexPath, defaultIndex.string())
@@ -338,17 +344,21 @@ func getIndex(indexPath string, defaultIndex index) (index, error) {
 }
 
 func setIndex(indexPath string, index index) {
+	if indexPath == "" {
+		log.Printf("index file path not provided, starting with index %d", index.value)
+		return
+	}
 	_, err := os.Stat(path.Dir(indexPath))
 	if errors.Is(err, os.ErrNotExist) {
 		err := os.MkdirAll(path.Dir(indexPath), os.ModePerm)
 		if err != nil {
-			fmt.Printf("unable to create index file parent directory: %s", err)
+			log.Printf("unable to create index file parent directory: %s", err)
 			return
 		}
 	}
 
 	err = os.WriteFile(indexPath, []byte(index.string()), 0644)
 	if err != nil {
-		fmt.Printf("unable to update index to %d: %s", index, err)
+		log.Printf("unable to update index to %d: %s", index, err)
 	}
 }

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -211,7 +211,7 @@ func (r *Reader) setIndex(indexPath string, index index) {
 }
 
 func (r *Reader) read(readCtx context.Context, startingIndex index) {
-	r.log.Errorf("starting %s tank read from index %d", r.topic, startingIndex.value)
+	r.log.Infof("starting %s tank read from index %d", r.topic, startingIndex.value)
 	err := r.readFromTank(readCtx, startingIndex)
 	if err != nil {
 		r.log.Errorf("%s read routine exited with error: %v", r.topic, err)

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -43,9 +43,8 @@ func (bf *boundaryFault) Error() string {
 }
 
 type IndexedMessage struct {
-	Message   []byte
-	Index     index
-	Timestamp int
+	Message []byte
+	Index   index
 }
 
 type index struct {
@@ -53,6 +52,7 @@ type index struct {
 }
 
 func newIndex(data string) (index, error) {
+	data = strings.TrimSpace(data)
 	if string(data) == endIndexStr {
 		return EndIndex, nil
 	}
@@ -130,7 +130,7 @@ func (r *Reader) Run(mainCtx context.Context) {
 	lastIndex, err := r.getIndex(r.indexPath, r.defaultIndex)
 	r.lastSavedIndex = lastIndex.value
 	if err != nil {
-		r.log.Errorf("Error in get index")
+		r.log.Errorf("Error in get index %v", err)
 		readCtxCancel()
 		return
 	}
@@ -154,7 +154,59 @@ func (r *Reader) Run(mainCtx context.Context) {
 				r.lastSavedIndex = lastIndex.value
 			}
 			nextSaveCheck = time.After(2 * time.Second)
+		case err := <-r.readDone:
+			var errBoundaryFault *boundaryFault
+			if err != nil && errors.As(err, &errBoundaryFault) {
+				r.log.Debugf("detected boundary fault, restarting %s tank read from index %d", r.topic, errBoundaryFault.nextAvailableIndex.value)
+				go r.read(mainCtx, readCtx, errBoundaryFault.nextAvailableIndex)
+			} else {
+				go r.read(mainCtx, readCtx, lastIndex.next())
+			}
 		}
+	}
+}
+
+func (r *Reader) getIndex(indexPath string, defaultIndex index) (index, error) {
+	if indexPath == "" {
+		r.log.Debugf("index file path not provided, starting with default index %s", defaultIndex.string())
+		return defaultIndex, nil
+	}
+	content, err := os.ReadFile(indexPath)
+	if errors.Is(err, os.ErrNotExist) {
+		r.log.Debugf("index file %s does not exist, starting with default index %s", indexPath, defaultIndex.string())
+		return defaultIndex, nil
+
+	} else if err != nil {
+		return defaultIndex, fmt.Errorf("encountered error reading index file, starting with default index %s: %s", defaultIndex.string(), err)
+	}
+
+	r.log.Debugf("found '%s' in index file", content)
+
+	index, err := newIndex(string(content))
+	if err != nil {
+		return defaultIndex, fmt.Errorf("encountered error while parsing index file content, starting with default index %s: %s", defaultIndex.string(), err)
+	}
+
+	return index, nil
+}
+
+func (r *Reader) setIndex(indexPath string, index index) {
+	if indexPath == "" {
+		r.log.Debugf("index file path not provided, starting with index %d", index.value)
+		return
+	}
+	_, err := os.Stat(path.Dir(indexPath))
+	if errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(path.Dir(indexPath), os.ModePerm)
+		if err != nil {
+			r.log.Debugf("unable to create index file parent directory: %s", err)
+			return
+		}
+	}
+
+	err = os.WriteFile(indexPath, []byte(index.string()), 0644)
+	if err != nil {
+		r.log.Debugf("unable to update index to %d: %s", index, err)
 	}
 }
 
@@ -172,10 +224,58 @@ func (r *Reader) read(mainCtx context.Context, readCtx context.Context, starting
 	r.readDone <- err
 }
 
-func (i *IndexedMessage) WithTimestamp(timestamp int) []byte {
-	parts := strings.Fields(string(i.Message))
-	parts[len(parts)-1] = strconv.Itoa(timestamp)
-	return []byte(strings.Join(parts, " "))
+func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err error) {
+	cmdArgs := []string{
+		"/opt/128technology/bin/tank-cli",
+		"-b",
+		fmt.Sprintf("%s:%d", r.tankAddress, r.tankPort),
+		"-t",
+		r.topic,
+		"consume",
+		"-F",
+		"seqnum,content",
+		startingIndex.string(),
+	}
+
+	cmd := r.tankReadCmdCtx(readCtx, cmdArgs[0], cmdArgs[1:]...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("unable to pipe %s tank output: %s", r.topic, err)
+	}
+
+	tankReader := bufio.NewReader(stdout)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("unable to start %s tank stream: %w", r.topic, err)
+	}
+
+	var parseErr error
+	var messages []*IndexedMessage
+
+	for {
+		select {
+		case <-readCtx.Done():
+			r.log.Errorf("%s read routine done", r.topic)
+			return nil
+		default:
+		}
+
+		messages, parseErr = parseLines(tankReader, r.topic)
+		if parseErr != nil {
+			r.log.Errorf("encountered error while parsing lines in %s output, will not attempt to parse more lines: %v", r.topic, parseErr)
+			return parseErr
+		}
+		var collectedMessages []IndexedMessage
+		for _, message := range messages {
+			if message.IsValid() {
+				collectedMessages = append(collectedMessages, *message)
+			}
+		}
+		select {
+		case <-readCtx.Done():
+			return nil
+		case r.sendChan <- collectedMessages:
+		}
+	}
 }
 
 func (i *IndexedMessage) IsValid() bool {
@@ -259,102 +359,4 @@ func isBoundaryFault(line string) (bool, index) {
 	}
 
 	return true, nextIndex
-}
-
-func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err error) {
-	cmdArgs := []string{
-		"/opt/128technology/bin/tank-cli",
-		"-b",
-		fmt.Sprintf("%s:%d", r.tankAddress, r.tankPort),
-		"-t",
-		r.topic,
-		"consume",
-		"-F",
-		"seqnum,content",
-		startingIndex.string(),
-	}
-
-	cmd := r.tankReadCmdCtx(readCtx, cmdArgs[0], cmdArgs[1:]...)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("unable to pipe %s tank output: %s", r.topic, err)
-	}
-
-	tankReader := bufio.NewReader(stdout)
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("unable to start %s tank stream: %w", r.topic, err)
-	}
-
-	var parseErr error
-	var messages []*IndexedMessage
-
-	for {
-		select {
-		case <-readCtx.Done():
-			r.log.Errorf("%s read routine done", r.topic)
-			return nil
-		default:
-		}
-
-		messages, parseErr = parseLines(tankReader, r.topic)
-		if parseErr != nil {
-			r.log.Errorf("encountered error while parsing lines in %s output, will not attempt to parse more lines: %v", r.topic, parseErr)
-			return parseErr
-		}
-		var collectedMessages []IndexedMessage
-		for _, message := range messages {
-			if message.IsValid() {
-				collectedMessages = append(collectedMessages, *message)
-			}
-		}
-		select {
-		case <-readCtx.Done():
-			return nil
-		case r.sendChan <- collectedMessages:
-		}
-	}
-}
-
-func (r *Reader) getIndex(indexPath string, defaultIndex index) (index, error) {
-	if indexPath == "" {
-		r.log.Debugf("index file path not provided, starting with default index %s", defaultIndex.string())
-		return defaultIndex, nil
-	}
-	content, err := os.ReadFile(indexPath)
-	if errors.Is(err, os.ErrNotExist) {
-		r.log.Debugf("index file %s does not exist, starting with default index %s", indexPath, defaultIndex.string())
-		return defaultIndex, nil
-
-	} else if err != nil {
-		return defaultIndex, fmt.Errorf("encountered error reading index file, starting with default index %s: %s", defaultIndex.string(), err)
-	}
-
-	r.log.Debugf("found '%s' in index file", content)
-
-	index, err := newIndex(string(content))
-	if err != nil {
-		return defaultIndex, fmt.Errorf("encountered error while parsing index file content, starting with default index %s: %s", defaultIndex.string(), err)
-	}
-
-	return index, nil
-}
-
-func (r *Reader) setIndex(indexPath string, index index) {
-	if indexPath == "" {
-		r.log.Debugf("index file path not provided, starting with index %d", index.value)
-		return
-	}
-	_, err := os.Stat(path.Dir(indexPath))
-	if errors.Is(err, os.ErrNotExist) {
-		err := os.MkdirAll(path.Dir(indexPath), os.ModePerm)
-		if err != nil {
-			r.log.Debugf("unable to create index file parent directory: %s", err)
-			return
-		}
-	}
-
-	err = os.WriteFile(indexPath, []byte(index.string()), 0644)
-	if err != nil {
-		r.log.Debugf("unable to update index to %d: %s", index, err)
-	}
 }

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -1,0 +1,354 @@
+package t128_tank
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	endIndexUint   = math.MaxUint64
+	endIndexStr    = "end"
+	startIndexUint = 0
+	startIndexStr  = "0"
+)
+
+var (
+	StartIndex         = index{value: startIndexUint}
+	EndIndex           = index{value: endIndexUint}
+	boundaryFaultRegex = regexp.MustCompile(`^Boundary Check fault. first available sequence number is (\d+), .*$`)
+	indexRegex         = regexp.MustCompile(`seq=(\d+?):(.*)$`)
+)
+
+type boundaryFault struct {
+	nextAvailableIndex index
+}
+
+func (bf *boundaryFault) Error() string {
+	return fmt.Sprintf("next available index is %d", bf.nextAvailableIndex.value)
+}
+
+// InfluxLine
+type IndexedMessage struct {
+	Message   []byte
+	Index     index
+	Timestamp int
+}
+
+type index struct {
+	value uint64
+}
+
+func newIndex(data string) (index, error) {
+	if string(data) == endIndexStr {
+		return EndIndex, nil
+	}
+	indexVal, err := strconv.ParseUint(data, 10, 64)
+	if err != nil {
+		return StartIndex, fmt.Errorf("unable to parse %s as integer: %s", data, err)
+	}
+	return index{value: indexVal}, nil
+}
+
+func (i index) string() string {
+	if i.value == endIndexUint {
+		return endIndexStr
+	}
+	return fmt.Sprintf("%d", i.value)
+}
+
+func (i index) next() index {
+	if i.value == startIndexUint || i.value == endIndexUint {
+		return i
+	}
+	return index{value: i.value + 1}
+}
+
+type CommandContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd
+
+type Reader struct {
+	topic          string
+	lastSavedIndex uint64
+	// used to send events from the read routine to the send routine
+	sendChan chan IndexedMessage
+	// the target address for the TANK instance
+	tankAddress string
+	// the target port for the TANK instance
+	tankPort int
+	// time to wait before restarting the tank read command
+	restartDelay time.Duration
+	// used to notify the main routine that the read routine finished with an error
+	readDone chan error
+	// used to mock tank read subprocess in testing
+	tankReadCmdCtx CommandContext
+	// path to the index file
+	indexPath string
+	// default index in case reading to/from the index file fails
+	defaultIndex index
+}
+
+func NewReader(tankAddress string, tankPort int, topic string, indexPath string, defaultIndex index) *Reader {
+	return &Reader{
+		topic:          topic,
+		tankReadCmdCtx: exec.CommandContext,
+		sendChan:       make(chan IndexedMessage),
+		readDone:       make(chan error),
+		restartDelay:   5 * time.Second,
+		tankAddress:    tankAddress,
+		tankPort:       tankPort,
+		indexPath:      indexPath,
+		defaultIndex:   defaultIndex,
+	}
+}
+
+func (r *Reader) withTankReadCommandContext(tankReadCmdCtx CommandContext) *Reader {
+	r.tankReadCmdCtx = tankReadCmdCtx
+	return r
+}
+
+func (r *Reader) Run(mainCtx context.Context, stopchan chan struct{}) {
+	readCtx, readCtxCancel := context.WithCancel(mainCtx)
+	paused := false
+	lastIndex, err := getIndex(r.indexPath, r.defaultIndex)
+	r.lastSavedIndex = lastIndex.value
+	if err != nil {
+		log.Printf("Error in get index")
+		return
+	}
+
+	nextSaveCheck := time.After(2 * time.Second)
+	defer func() {
+		readCtxCancel()
+		setIndex(r.indexPath, index{value: r.lastSavedIndex})
+	}()
+
+	go r.read(mainCtx, readCtx, lastIndex.next())
+
+	for {
+		select {
+		case <-mainCtx.Done():
+			fmt.Printf("%s reader done", r.topic)
+			readCtxCancel()
+			return
+		case <-nextSaveCheck:
+			if lastIndex.value > r.lastSavedIndex {
+				setIndex(r.indexPath, lastIndex)
+				r.lastSavedIndex = lastIndex.value
+			}
+			nextSaveCheck = time.After(2 * time.Second)
+		case err := <-r.readDone:
+			if !paused {
+				readCtx, readCtxCancel = context.WithCancel(mainCtx)
+				var boundaryFault *boundaryFault
+				if err != nil && errors.As(err, &boundaryFault) {
+					fmt.Printf("detected boundary fault, restarting %s tank read from index %d", r.topic, boundaryFault.nextAvailableIndex.value)
+					go r.read(mainCtx, readCtx, boundaryFault.nextAvailableIndex)
+				} else {
+					go r.read(mainCtx, readCtx, lastIndex.next())
+				}
+			} else {
+				fmt.Printf("reader is paused, skipping %s tank read restart", r.topic)
+			}
+		}
+	}
+}
+
+func (r *Reader) read(mainCtx context.Context, readCtx context.Context, startingIndex index) {
+	fmt.Printf("starting %s tank read from index %d", r.topic, startingIndex.value)
+	err := r.readFromTank(readCtx, startingIndex)
+	if err != nil {
+		fmt.Printf("%s read routine exited with error: %v", r.topic, err)
+	}
+
+	if mainCtx.Err() == nil {
+		time.Sleep(r.restartDelay)
+	}
+
+	r.readDone <- err
+}
+
+func (i *IndexedMessage) WithTimestamp(timestamp int) []byte {
+	parts := strings.Fields(string(i.Message))
+	parts[len(parts)-1] = strconv.Itoa(timestamp)
+	return []byte(strings.Join(parts, " "))
+}
+
+func (i *IndexedMessage) IsValid() bool {
+	return len(i.Message) > 0
+}
+
+func parseLines(tankReader *bufio.Reader, topic string) (messages []*IndexedMessage, err error) {
+	messages = make([]*IndexedMessage, 0, 1)
+	rawLines, err := tankReader.ReadBytes('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return messages, err
+	} else if len(rawLines) == 0 {
+		return messages, fmt.Errorf("found empty newline in %s tank stream, continuing", topic)
+	}
+	rawLines = bytes.TrimSpace(rawLines)
+	lines := bytes.Split(rawLines, []byte("\n"))
+	for _, rawLine := range lines {
+		line := string(rawLine)
+
+		if len(line) == 0 {
+			continue
+		}
+		message, err := ParseTankLine(rawLine)
+		if err != nil {
+			fmt.Printf("parse failure for topic %s: %v", topic, err)
+			continue
+		}
+
+		if message == nil {
+			if isBoundaryFault, nextAvailabelIndex := isBoundaryFault(line); isBoundaryFault {
+				return messages, fmt.Errorf(
+					"parsed boundary fault: %w",
+					&boundaryFault{nextAvailableIndex: nextAvailabelIndex},
+				)
+			}
+
+			fmt.Printf("skipping %s line because regex matching failed: %s", topic, line)
+			continue
+		}
+
+		message.Message = bytes.TrimRight(message.Message, "\n")
+		messages = append(messages, message)
+	}
+
+	return messages, err
+}
+
+func ParseTankLine(line []byte) (*IndexedMessage, error) {
+	matches := indexRegex.FindSubmatch(line)
+	if len(matches) != 3 {
+		return nil, errors.New("invalid line format")
+	}
+
+	index, err := newIndex(string(matches[1]))
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse index %s, skipping: %s", matches[1], err)
+	}
+
+	message := matches[2]
+	return &IndexedMessage{
+		Message: message,
+		Index:   index,
+	}, nil
+}
+
+func isBoundaryFault(line string) (bool, index) {
+	matches := boundaryFaultRegex.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return false, StartIndex
+	}
+
+	nextIndex, err := newIndex(matches[1])
+	if err != nil {
+		fmt.Printf("unable to parse index after detecting boundary fault: %s", err)
+		return false, StartIndex
+	}
+
+	return true, nextIndex
+}
+
+func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err error) {
+	cmdArgs := []string{
+		"/opt/128technology/bin/tank-cli",
+		"-b",
+		fmt.Sprintf("%s:%d", r.tankAddress, r.tankPort),
+		"-t",
+		r.topic,
+		"consume",
+		"-F",
+		"seqnum,content",
+		startingIndex.string(),
+	}
+
+	cmd := r.tankReadCmdCtx(readCtx, cmdArgs[0], cmdArgs[1:]...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("unable to pipe %s tank output: %s", r.topic, err)
+	}
+
+	tankReader := bufio.NewReader(stdout)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("unable to start %s tank stream: %w", r.topic, err)
+	}
+
+	var parseErr error
+	var messages []*IndexedMessage
+
+	for {
+		select {
+		case <-readCtx.Done():
+			fmt.Printf("%s read routine done", r.topic)
+			return nil
+		default:
+		}
+
+		messages, parseErr = parseLines(tankReader, r.topic)
+		if parseErr != nil {
+			fmt.Printf("encountered error while parsing lines in %s output, will not attempt to parse more lines: %v", r.topic, parseErr)
+			return parseErr
+		}
+		fmt.Println("After Parse Line inside read from tank")
+		for _, message := range messages {
+			if message.IsValid() {
+				select {
+				case <-readCtx.Done():
+					return nil
+				case r.sendChan <- *message:
+				}
+			}
+		}
+	}
+}
+
+func getIndex(indexPath string, defaultIndex index) (index, error) {
+	content, err := os.ReadFile(indexPath)
+	if errors.Is(err, os.ErrNotExist) {
+		log.Printf("index file %s does not exist, starting with default index %s", indexPath, defaultIndex.string())
+		return defaultIndex, nil
+
+	} else if err != nil {
+		return defaultIndex, fmt.Errorf("encountered error reading index file, starting with default index %s: %s", defaultIndex.string(), err)
+	}
+
+	log.Printf("found '%s' in index file", content)
+
+	index, err := newIndex(string(content))
+	if err != nil {
+		return defaultIndex, fmt.Errorf("encountered error while parsing index file content, starting with default index %s: %s", defaultIndex.string(), err)
+	}
+
+	return index, nil
+}
+
+func setIndex(indexPath string, index index) {
+	_, err := os.Stat(path.Dir(indexPath))
+	if errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(path.Dir(indexPath), os.ModePerm)
+		if err != nil {
+			fmt.Printf("unable to create index file parent directory: %s", err)
+			return
+		}
+	}
+
+	err = os.WriteFile(indexPath, []byte(index.string()), 0644)
+	if err != nil {
+		fmt.Printf("unable to update index to %d: %s", index, err)
+	}
+}

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -3,7 +3,9 @@ package t128_tank
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +33,11 @@ var sampleConfig = `
 ## Server Address to get tank data from.
 # server_address = "127.0.0.1"
 `
+
+var (
+	typePattern       = `,type=([^\s]+)`
+	recordTypePattern = `recordType=([^\s]+)`
+)
 
 type T128Tank struct {
 	IndexFile     string `toml:"index_file"`
@@ -76,11 +83,20 @@ func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
 				return
 			case messages := <-reader.sendChan:
 				for _, message := range messages {
+
+					tags := map[string]string{
+						"index": strconv.FormatUint(message.Index.value, 10),
+					}
+					if strings.ToLower(plugin.Topic) == "events" {
+						messageType := extractMessageType(string(message.Message), typePattern)
+						tags["type"] = messageType
+					} else if strings.ToLower(plugin.Topic) == "session_records" {
+						messageType := extractMessageType(string(message.Message), recordTypePattern)
+						tags["recordType"] = messageType
+					}
 					acc.AddFields("t128_tank", map[string]interface{}{
 						"message": string(message.Message),
-					}, map[string]string{
-						"index": strconv.FormatUint(message.Index.value, 10),
-					}, time.Now())
+					}, tags, time.Now())
 				}
 			}
 		}
@@ -100,6 +116,16 @@ func (plugin *T128Tank) Stop() {
 		plugin.cancel()
 	}
 	plugin.mainWG.Wait()
+}
+
+func extractMessageType(message string, pattern string) string {
+
+	regex := regexp.MustCompile(pattern)
+	match := regex.FindStringSubmatch(message)
+	if len(match) > 1 {
+		return match[1]
+	}
+	return ""
 }
 
 func (plugin *T128Tank) checkConfig() error {

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -1,0 +1,98 @@
+package t128_tank
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs"
+)
+
+const (
+	T128TankAddr = "127.0.0.1"
+	T128TankPort = 11011
+)
+
+var sampleConfig = `
+[[inputs.t128_tank]]
+## A name for the collector which will be used as the measurement name of the produced data.
+# collector_name = ""
+
+## Required. A path for index file.
+# index_file = ""
+
+## Required. Type of topic.
+# topic = "events"
+
+## Required. Port Number to get tank data from.
+# port_number = 11011
+
+## Required. Port Address to get tank data from.
+# port_address = "127.0.0.1"
+`
+
+type T128Tank struct {
+	CollectorName string `toml:"collector_name"`
+	IndexFile     string `toml:"index_file"`
+	Topic         string `toml:"topic"`
+	PortNumber    int    `toml:"port_number"`
+	PortAddress   string `toml:"port_address"`
+	stop          chan struct{}
+}
+
+func (*T128Tank) SampleConfig() string {
+	return sampleConfig
+}
+
+func (*T128Tank) Description() string {
+	return "Run TANK as a long-running input plugin"
+}
+
+func (plugin *T128Tank) Init() error {
+	err := plugin.checkConfig()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (plugin *T128Tank) Gather(_ telegraf.Accumulator) error {
+	return nil
+}
+
+func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
+
+	var reader = NewReader(plugin.PortAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, StartIndex)
+	go func() {
+		reader.Run(context.Background(), plugin.stop)
+	}()
+
+	return nil
+}
+
+func (plugin *T128Tank) Stop() {
+	close(plugin.stop)
+}
+
+func (plugin *T128Tank) checkConfig() error {
+	if plugin.IndexFile == "" {
+		return fmt.Errorf("index_file is a required configuration field")
+	}
+
+	if plugin.Topic == "" {
+		return fmt.Errorf("topic is a required configuration field")
+	}
+
+	return nil
+}
+
+func init() {
+	inputs.Add("t128_tank", func() telegraf.Input {
+		return &T128Tank{
+			PortNumber:  T128TankPort,
+			PortAddress: T128TankAddr,
+			stop:        make(chan struct{}),
+		}
+	})
+}

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -89,8 +89,8 @@ func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
 
 	plugin.mainWG.Add(1)
 	go func() {
-		reader.Run(plugin.ctx)
 		defer plugin.mainWG.Done()
+		reader.Run(plugin.ctx)
 	}()
 
 	return nil

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -88,10 +88,10 @@ func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
 						"index": strconv.FormatUint(message.Index.value, 10),
 					}
 					if strings.ToLower(plugin.Topic) == "events" {
-						messageType := extractMessageType(string(message.Message), typePattern)
+						messageType := extractTopicType(string(message.Message), typePattern)
 						tags["type"] = messageType
 					} else if strings.ToLower(plugin.Topic) == "session_records" {
-						messageType := extractMessageType(string(message.Message), recordTypePattern)
+						messageType := extractTopicType(string(message.Message), recordTypePattern)
 						tags["recordType"] = messageType
 					}
 					acc.AddFields("t128_tank", map[string]interface{}{
@@ -118,8 +118,7 @@ func (plugin *T128Tank) Stop() {
 	plugin.mainWG.Wait()
 }
 
-func extractMessageType(message string, pattern string) string {
-
+func extractTopicType(message string, pattern string) string {
 	regex := regexp.MustCompile(pattern)
 	match := regex.FindStringSubmatch(message)
 	if len(match) > 1 {

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -38,6 +39,7 @@ type T128Tank struct {
 	ServerAddress string `toml:"server_address"`
 	Log           telegraf.Logger
 	ctx           context.Context
+	mainWG        sync.WaitGroup
 	cancel        context.CancelFunc
 }
 
@@ -65,8 +67,10 @@ func (plugin *T128Tank) Gather(_ telegraf.Accumulator) error {
 func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
 	plugin.ctx, plugin.cancel = context.WithCancel(context.Background())
 
-	reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, StartIndex, plugin.Log, plugin.ctx, acc)
+	reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, StartIndex, plugin.Log, acc)
+	plugin.mainWG.Add(1)
 	go func() {
+		defer plugin.mainWG.Done()
 		for {
 			select {
 			case <-plugin.ctx.Done():
@@ -83,8 +87,10 @@ func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
 		}
 	}()
 
+	plugin.mainWG.Add(1)
 	go func() {
-		reader.Run()
+		reader.Run(plugin.ctx)
+		defer plugin.mainWG.Done()
 	}()
 
 	return nil
@@ -94,6 +100,7 @@ func (plugin *T128Tank) Stop() {
 	if plugin.cancel != nil {
 		plugin.cancel()
 	}
+	plugin.mainWG.Wait()
 }
 
 func (plugin *T128Tank) checkConfig() error {

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -66,7 +66,6 @@ func (plugin *T128Tank) Gather(_ telegraf.Accumulator) error {
 
 func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
 	plugin.ctx, plugin.cancel = context.WithCancel(context.Background())
-
 	reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, StartIndex, plugin.Log, acc)
 	plugin.mainWG.Add(1)
 	go func() {

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -3,6 +3,8 @@ package t128_tank
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/plugins/inputs"
@@ -15,29 +17,28 @@ const (
 
 var sampleConfig = `
 [[inputs.t128_tank]]
-## A name for the collector which will be used as the measurement name of the produced data.
-# collector_name = ""
-
-## Required. A path for index file.
+## A (unique) file to use for index tracking. 
+## This tracking allows each event to be produced once.
 # index_file = ""
 
-## Required. Type of topic.
+## Required. The TANK topic to consume.
 # topic = "events"
 
-## Required. Port Number to get tank data from.
+## Port Number to get tank data from.
 # port_number = 11011
 
-## Required. Port Address to get tank data from.
-# port_address = "127.0.0.1"
+## Server Address to get tank data from.
+# server_address = "127.0.0.1"
 `
 
 type T128Tank struct {
-	CollectorName string `toml:"collector_name"`
 	IndexFile     string `toml:"index_file"`
 	Topic         string `toml:"topic"`
 	PortNumber    int    `toml:"port_number"`
-	PortAddress   string `toml:"port_address"`
-	stop          chan struct{}
+	ServerAddress string `toml:"server_address"`
+	Log           telegraf.Logger
+	ctx           context.Context
+	cancel        context.CancelFunc
 }
 
 func (*T128Tank) SampleConfig() string {
@@ -62,24 +63,40 @@ func (plugin *T128Tank) Gather(_ telegraf.Accumulator) error {
 }
 
 func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
+	plugin.ctx, plugin.cancel = context.WithCancel(context.Background())
 
-	var reader = NewReader(plugin.PortAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, StartIndex)
+	reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, StartIndex, plugin.Log, plugin.ctx, acc)
 	go func() {
-		reader.Run(context.Background(), plugin.stop)
+		for {
+			select {
+			case <-plugin.ctx.Done():
+				return
+			case messages := <-reader.sendChan:
+				for _, message := range messages {
+					acc.AddFields("t128_tank", map[string]interface{}{
+						"message": string(message.Message),
+					}, map[string]string{
+						"index": strconv.FormatUint(message.Index.value, 10),
+					}, time.Now())
+				}
+			}
+		}
+	}()
+
+	go func() {
+		reader.Run()
 	}()
 
 	return nil
 }
 
 func (plugin *T128Tank) Stop() {
-	close(plugin.stop)
+	if plugin.cancel != nil {
+		plugin.cancel()
+	}
 }
 
 func (plugin *T128Tank) checkConfig() error {
-	if plugin.IndexFile == "" {
-		return fmt.Errorf("index_file is a required configuration field")
-	}
-
 	if plugin.Topic == "" {
 		return fmt.Errorf("topic is a required configuration field")
 	}
@@ -90,9 +107,8 @@ func (plugin *T128Tank) checkConfig() error {
 func init() {
 	inputs.Add("t128_tank", func() telegraf.Input {
 		return &T128Tank{
-			PortNumber:  T128TankPort,
-			PortAddress: T128TankAddr,
-			stop:        make(chan struct{}),
+			PortNumber:    T128TankPort,
+			ServerAddress: T128TankAddr,
 		}
 	})
 }

--- a/plugins/inputs/t128_tank/t128_tank_test.go
+++ b/plugins/inputs/t128_tank/t128_tank_test.go
@@ -1,35 +1,223 @@
 package t128_tank
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/influxdata/telegraf/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestT128Tank(t *testing.T) {
-	plugin := &T128Tank{
-		Topic: "events",
-	}
-	var acc testutil.Accumulator
-	err := plugin.Start(&acc)
-	assert.NoError(t, err)
-	plugin.Stop()
+type mockTankCommadContext func(ctx context.Context, name string, arg ...string) *exec.Cmd
 
+func (mctx mockTankCommadContext) CommandContext(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	return mctx(ctx, name, arg...)
+}
+
+func TestT128TankReader(t *testing.T) {
+	testcases := []struct {
+		Name                   string
+		IndexFile              string
+		IndexFileContent       string
+		Topic                  string
+		PortNumber             int
+		ServerAddress          string
+		TankReadCommandContext mockTankCommadContext
+		DefaultIndex           index
+		ExpectedMetrics        []IndexedMessage
+	}{
+		{
+			Name:          "index file with no value",
+			Topic:         "events",
+			PortNumber:    11011,
+			ServerAddress: "127.0.0.2",
+			DefaultIndex:  StartIndex,
+			TankReadCommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+				cmd := exec.CommandContext(ctx, "echo", "seq=1:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775")
+				return cmd
+			},
+			ExpectedMetrics: []IndexedMessage{
+				{
+					Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
+					Index:   index{value: 1},
+				},
+			},
+		},
+		{
+			Name:             "index file with value",
+			IndexFileContent: "150",
+			Topic:            "events",
+			PortNumber:       11011,
+			ServerAddress:    "127.0.0.2",
+			DefaultIndex:     StartIndex,
+			TankReadCommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+				cmd := exec.CommandContext(ctx, "echo", "seq=150:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775")
+				return cmd
+			},
+			ExpectedMetrics: []IndexedMessage{
+				{
+					Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
+					Index:   index{value: 150},
+				},
+			},
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			plugin := &T128Tank{
+				IndexFile:     testcase.IndexFile,
+				Topic:         testcase.Topic,
+				PortNumber:    testcase.PortNumber,
+				ServerAddress: testcase.ServerAddress,
+			}
+
+			var acc testutil.Accumulator
+			var receivedMessages []IndexedMessage
+			ctx, cancel := context.WithCancel(context.Background())
+			var wg sync.WaitGroup
+			indexFileName := strings.ReplaceAll(testcase.Name, " ", "_")
+			plugin.IndexFile = path.Join(t.TempDir(), fmt.Sprintf("%s.index", indexFileName))
+			if testcase.IndexFileContent != "" {
+				err := os.WriteFile(plugin.IndexFile, []byte(testcase.IndexFileContent), 0755)
+				assert.NoError(t, err)
+			}
+			reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, testcase.DefaultIndex, testutil.Logger{}, &acc).withTankReadCommandContext(testcase.TankReadCommandContext)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				reader.Run(ctx)
+			}()
+
+			select {
+			case <-time.After(5 * time.Second):
+				t.Log("no messages received")
+			case <-ctx.Done():
+				t.Log("context canceled")
+			case messages := <-reader.sendChan:
+				receivedMessages = append(receivedMessages, messages...)
+			}
+
+			cancel()
+
+			if len(testcase.ExpectedMetrics) > 0 && receivedMessages != nil {
+				assert.Equal(t, testcase.ExpectedMetrics, receivedMessages)
+
+			}
+		})
+	}
+}
+
+func TestBoundaryFault(t *testing.T) {
+	testcases := []struct {
+		Name                   string
+		IndexFile              string
+		IndexFileContent       string
+		Topic                  string
+		PortNumber             int
+		ServerAddress          string
+		TankReadCommandContext mockTankCommadContext
+		DefaultIndex           index
+		ExpectedError          string
+	}{
+		{
+			Name:          "boundary-fault",
+			Topic:         "events",
+			PortNumber:    11011,
+			ServerAddress: "127.0.0.2",
+			DefaultIndex:  StartIndex,
+			TankReadCommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+				return exec.CommandContext(ctx, "echo", "Boundary Check fault. first available sequence number is 150, high watermark is 200")
+			},
+			ExpectedError: "parsed boundary fault: next available index is 150",
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			plugin := &T128Tank{
+				IndexFile:     testcase.IndexFile,
+				Topic:         testcase.Topic,
+				PortNumber:    testcase.PortNumber,
+				ServerAddress: testcase.ServerAddress,
+			}
+
+			var acc testutil.Accumulator
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			indexFileName := strings.ReplaceAll(testcase.Name, " ", "_")
+			plugin.IndexFile = path.Join(t.TempDir(), fmt.Sprintf("%s.index", indexFileName))
+			if testcase.IndexFileContent != "" {
+				err := os.WriteFile(plugin.IndexFile, []byte(testcase.IndexFileContent), 0755)
+				assert.NoError(t, err)
+			}
+			reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, testcase.DefaultIndex, testutil.Logger{}, &acc).withTankReadCommandContext(testcase.TankReadCommandContext)
+			var receivedErrorMessage string
+			go func() {
+				err := reader.readFromTank(ctx, StartIndex)
+				if err != nil {
+					receivedErrorMessage = err.Error()
+				}
+			}()
+
+			time.Sleep(1 * time.Second)
+
+			assert.Equal(t, testcase.ExpectedError, receivedErrorMessage)
+		})
+	}
 }
 
 func TestParseTankLine(t *testing.T) {
-	inputMessage := "seq=150:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"
-	expectedMessage := &IndexedMessage{
-		Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
-		Index:   index{value: 150},
+	testcases := []struct {
+		Name            string
+		InputMessage    string
+		ExpectedMessage *IndexedMessage
+	}{
+		{
+			Name:         "input-message-with-newline",
+			InputMessage: "seq=8:type=LINK_UP, Timestamp=2022-03-25T00:00:00Z,Raw=hello\nworld",
+			ExpectedMessage: &IndexedMessage{
+				Message: []byte("type=LINK_UP, Timestamp=2022-03-25T00:00:00Z,Raw=hello\nworld"),
+				Index:   index{value: 8},
+			},
+		},
+		{
+			Name:         "simple",
+			InputMessage: "seq=150:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775",
+			ExpectedMessage: &IndexedMessage{
+				Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
+				Index:   index{value: 150},
+			},
+		},
 	}
-	result, err := ParseTankLine([]byte(inputMessage))
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-		return
+	for _, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			result, err := ParseTankLine([]byte(testcase.InputMessage))
+			assert.NoError(t, err)
+			assert.Equal(t, result, testcase.ExpectedMessage)
+		})
 	}
-	if result.Index.value != expectedMessage.Index.value || string(result.Message) != string(expectedMessage.Message) {
-		t.Errorf("ParseTankLine(%s) returned unexpected result: %+v, expected: %+v", inputMessage, result, expectedMessage)
-	}
+}
+
+func TestIndexParsing(t *testing.T) {
+	index, err := newIndex("0")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), index.value)
+
+	index, err = newIndex("end")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(endIndexUint), index.value)
+
+	index, err = newIndex("3\n")
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(3), index.value)
+
+	_, err = newIndex("foo")
+	assert.Error(t, err)
 }

--- a/plugins/inputs/t128_tank/t128_tank_test.go
+++ b/plugins/inputs/t128_tank/t128_tank_test.go
@@ -1,0 +1,35 @@
+package t128_tank
+
+import (
+	"testing"
+
+	"github.com/influxdata/telegraf/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestT128Tank(t *testing.T) {
+	plugin := &T128Tank{
+		Topic: "events",
+	}
+	var acc testutil.Accumulator
+	err := plugin.Start(&acc)
+	assert.NoError(t, err)
+	plugin.Stop()
+
+}
+
+func TestParseTankLine(t *testing.T) {
+	inputMessage := "seq=150:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"
+	expectedMessage := &IndexedMessage{
+		Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
+		Index:   index{value: 150},
+	}
+	result, err := ParseTankLine([]byte(inputMessage))
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+	if result.Index.value != expectedMessage.Index.value || string(result.Message) != string(expectedMessage.Message) {
+		t.Errorf("ParseTankLine(%s) returned unexpected result: %+v, expected: %+v", inputMessage, result, expectedMessage)
+	}
+}

--- a/plugins/inputs/t128_tank/t128_tank_test.go
+++ b/plugins/inputs/t128_tank/t128_tank_test.go
@@ -88,7 +88,15 @@ func TestT128TankReader(t *testing.T) {
 				err := os.WriteFile(plugin.IndexFile, []byte(testcase.IndexFileContent), 0755)
 				assert.NoError(t, err)
 			}
-			reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, testcase.DefaultIndex, testutil.Logger{}, &acc).withTankReadCommandContext(testcase.TankReadCommandContext)
+			reader := NewReader(
+				plugin.ServerAddress,
+				plugin.PortNumber,
+				plugin.Topic,
+				plugin.IndexFile,
+				testcase.DefaultIndex,
+				testutil.Logger{},
+				&acc,
+			).withTankReadCommandContext(testcase.TankReadCommandContext)
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -148,6 +156,7 @@ func TestBoundaryFault(t *testing.T) {
 			}
 
 			var acc testutil.Accumulator
+			var wg sync.WaitGroup
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -157,16 +166,26 @@ func TestBoundaryFault(t *testing.T) {
 				err := os.WriteFile(plugin.IndexFile, []byte(testcase.IndexFileContent), 0755)
 				assert.NoError(t, err)
 			}
-			reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, testcase.DefaultIndex, testutil.Logger{}, &acc).withTankReadCommandContext(testcase.TankReadCommandContext)
+			reader := NewReader(
+				plugin.ServerAddress,
+				plugin.PortNumber,
+				plugin.Topic,
+				plugin.IndexFile,
+				testcase.DefaultIndex,
+				testutil.Logger{},
+				&acc,
+			).withTankReadCommandContext(testcase.TankReadCommandContext)
 			var receivedErrorMessage string
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				err := reader.readFromTank(ctx, StartIndex)
 				if err != nil {
 					receivedErrorMessage = err.Error()
 				}
 			}()
 
-			time.Sleep(1 * time.Second)
+			wg.Wait()
 
 			assert.Equal(t, testcase.ExpectedError, receivedErrorMessage)
 		})
@@ -180,11 +199,11 @@ func TestParseTankLine(t *testing.T) {
 		ExpectedMessage *IndexedMessage
 	}{
 		{
-			Name:         "input-message-with-newline",
-			InputMessage: "seq=8:type=LINK_UP, Timestamp=2022-03-25T00:00:00Z,Raw=hello\nworld",
+			Name:         "input-message",
+			InputMessage: "seq=861:events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail='node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697466322.733:10608): pid=16967 uid=0 auid=4294967295 ses=4294967295 msg='op=PAM:authentication grantors=pam_faillock,pam_unix acct=\"centos\" exe=\"/usr/sbin/sshd\" hostname=172.18.15.253 addr=172.18.15.253 terminal=ssh res=success'',permitted=t,user='centos' 1697466322733010608",
 			ExpectedMessage: &IndexedMessage{
-				Message: []byte("type=LINK_UP, Timestamp=2022-03-25T00:00:00Z,Raw=hello\nworld"),
-				Index:   index{value: 8},
+				Message: []byte("events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail='node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697466322.733:10608): pid=16967 uid=0 auid=4294967295 ses=4294967295 msg='op=PAM:authentication grantors=pam_faillock,pam_unix acct=\"centos\" exe=\"/usr/sbin/sshd\" hostname=172.18.15.253 addr=172.18.15.253 terminal=ssh res=success'',permitted=t,user='centos' 1697466322733010608"),
+				Index:   index{value: 861},
 			},
 		},
 		{

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -34,7 +34,7 @@ def build(args):
         subprocess.run(
             build_docker_command(
                 args.docker_file,
-                ["make", "x86_64.rpm"],
+                ["make", "clean", "x86_64.rpm"],
                 interactive=False,
                 env=env,
             ),
@@ -52,7 +52,7 @@ def shell(args):
 def create_docker_env(docker_file):
     try:
         subprocess.check_call(
-            ["docker", "build", "-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
+            ["docker", "build", "--no-cache","-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
         )
     except subprocess.CalledProcessError as error:
         print("Failed to build the docker image")

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -52,7 +52,7 @@ def shell(args):
 def create_docker_env(docker_file):
     try:
         subprocess.check_call(
-            ["docker", "build", "--no-cache","-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
+            ["docker", "build", "--no-cache", "-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
         )
     except subprocess.CalledProcessError as error:
         print("Failed to build the docker image")

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -55,10 +55,11 @@ def shell(args):
 
 
 def create_docker_env(docker_file):
+    cmd = ["docker", "build", "-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
+    if "--no-cache" in sys.argv:
+        cmd.insert(2, "--no-cache")
     try:
-        subprocess.check_call(
-            ["docker", "build", "--no-cache", "-t", IMAGE_NAME, "-f", docker_file, SCRIPTS]
-        )
+        subprocess.check_call(cmd)
     except subprocess.CalledProcessError as error:
         print("Failed to build the docker image")
         sys.exit(1)
@@ -140,6 +141,12 @@ def parse_args():
     build_parser.add_argument(
         "--clean", 
         help="Whether to clean up and build everything from scratch", 
+        action="store_true",
+    )
+
+    build_parser.add_argument(
+        "--no-cache", 
+        help="Whether to build everything from scratch or from cache", 
         action="store_true",
     )
 

--- a/scripts/docker-env
+++ b/scripts/docker-env
@@ -30,11 +30,16 @@ def build(args):
         "rpm_version": f"{args.version}-{args.release}",
     }
 
+    build_commands = ["make", "x86_64.rpm"]
+
+    if args.clean:
+        build_commands.insert(1, "clean")
+
     try:
         subprocess.run(
             build_docker_command(
                 args.docker_file,
-                ["make", "clean", "x86_64.rpm"],
+                build_commands,
                 interactive=False,
                 env=env,
             ),
@@ -129,6 +134,12 @@ def parse_args():
     build_parser.add_argument(
         "--no-fetch",
         help="Whether to fetch dependencies before building. If not, you should have run `make deps` in your source directory.",
+        action="store_true",
+    )
+
+    build_parser.add_argument(
+        "--clean", 
+        help="Whether to clean up and build everything from scratch", 
         action="store_true",
     )
 


### PR DESCRIPTION
### Description

In order to translate `session-records` and `events` to native telegraf we decided to create a new input telegraf called `t128_tank`

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.
- [x] Manual Testing & ScreenGrabs
- [x] Update Docker Command with flags

### Command ###

```
./scripts/docker-env build --clean --no-cache --version ${value} --release ${value}
```

### Testing ###

- [x] Given no index file, we read from the beginning of the topic
- [x] Given an index file, we read from that point in the topic
- [x] Given an index file location where the file doesn’t exist, the file is created and written as lines are processed
- [x] Given an index file with an index beyond what is currently in TANK, the reader identifies the boundary fault and starts from the beginning of the topic
- [x] Verify the behavior when TANK is not running
- [x] Verify the behavior when TANK goes from running to stopped
- [x] Verify the behavior when TANK goes from not running to running
- [x] Tagpass for session_records and events


#### Testcase 1 config & output ####
```
[inputs]
[[inputs.t128_tank]]
topic="events"
[outputs]
[[outputs.file]]
files=["/home/centos/tank.txt"]
```

```
2023-10-13T17:50:52Z I! Starting Telegraf 1.22.10-a05488d6
2023-10-13T17:50:52Z I! Loaded inputs: t128_tank
2023-10-13T17:50:52Z I! Loaded aggregators:
2023-10-13T17:50:52Z I! Loaded processors:
2023-10-13T17:50:52Z I! Loaded outputs: file
2023-10-13T17:50:52Z I! Tags enabled: host=t137-dut3.openstacklocal
2023-10-13T17:50:52Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"t137-dut3.openstacklocal", Flush Interval:10s
2023-10-13T17:50:52Z E! [inputs.t128_tank] starting events tank read from index 0
```

```
t128_tank,host=t137-dut3.openstacklocal,index=581 message="events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697214079.153:8859): pid=19533 uid=0 auid=4294967295 ses=4294967295 msg='op=pubkey acct=\\\"centos\\\" exe=\\\"/usr/sbin/sshd\\\" hostname=? addr=172.18.15.253 terminal=ssh res=failed'\",fail_reason=\"pubkey\",permitted=f,user=\"centos\" 1697214079153008859" 1697219452346984804
```

#### Testcase 2 config & output ####
```
[inputs]
[[inputs.t128_tank]]
topic="events"
index_file="/var/lib/128T-cloud-intel-agent/index/cloud_events.index"
[outputs]
[[outputs.file]]
files=["/home/centos/tank.txt"]
```

```
[root@t137-dut3 centos]# telegraf --config sample.conf
2023-10-13T18:31:54Z I! Starting Telegraf 1.22.10-a05488d6
2023-10-13T18:31:54Z I! Loaded inputs: t128_tank
2023-10-13T18:31:54Z I! Loaded aggregators:
2023-10-13T18:31:54Z I! Loaded processors:
2023-10-13T18:31:54Z I! Loaded outputs: file
2023-10-13T18:31:54Z I! Tags enabled: host=t137-dut3.openstacklocal log_level=debugf
2023-10-13T18:31:54Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"t137-dut3.openstacklocal", Flush Interval:10s
2023-10-13T18:31:54Z E! [inputs.t128_tank] starting events tank read from index 87
2023-10-13T18:31:54Z E! [inputs.t128_tank] encountered error while parsing lines in events output, will not attempt to parse more lines: parsed boundary fault: next available index is 588
2023-10-13T18:31:54Z E! [inputs.t128_tank] events read routine exited with error: parsed boundary fault: next available index is 588
2023-10-13T18:31:59Z E! [inputs.t128_tank] starting events tank read from index 588
^C2023-10-13T18:32:43Z E! [inputs.t128_tank] events reader done
2023-10-13T18:32:43Z E! [inputs.t128_tank] encountered error while parsing lines in events output, will not attempt to parse more lines: found empty newline in events tank stream, continuing
2023-10-13T18:32:43Z E! [inputs.t128_tank] events read routine exited with error: found empty newline in events tank stream, continuing
2023-10-13T18:32:43Z I! [agent] Hang on, flushing any cached metrics before shutdown
2023-10-13T18:32:43Z I! [agent] Stopping running outputs
```
```
[root@t137-dut3 centos]# tail -f tank.txt
t128_tank,host=t137-dut3.openstacklocal,index=588,log_level=debugf message="events,collector_id=auditd,node=westB,subtype=ntp_adjustment,type=system event_detail=\"node=t137-dut3.openstacklocal type=SYSCALL msg=audit(1697216526.571:8918): arch=c000003e syscall=159 success=yes exit=0 a0=5626b096a980 a1=1 a2=0 a3=5626b09fa55c items=0 ppid=1 pid=7236 auid=4294967295 uid=38 gid=38 euid=38 suid=38 fsuid=38 egid=38 sgid=38 fsgid=38 tty=(none) ses=4294967295 comm=\\\"ntpd\\\" exe=\\\"/usr/sbin/ntpd\\\" key=\\\"128T\\\" old_time=2023-10-13T17:02:06.571000Z new_time=2023-10-13T17:02:06Z\",new_date_time=\"2023-10-13T17:02:06Z\",user=\"ntp\" 1697216526571008918" 1697221919544233297
```

#### Testcase 3 config & output ####
```
[inputs]
[[inputs.t128_tank]]
topic="events"
index_file="/home/centos/test.index"
[outputs]
[[outputs.file]]
files=["/home/centos/tank.txt"]
```
```
t128_tank,host=t137-dut3.openstacklocal,index=553 message="events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697197701.648:8589): pid=2800 uid=0 auid=1000 ses=73 msg='op=PAM:authentication grantors=pam_rootok acct=\\\"root\\\" exe=\\\"/usr/bin/su\\\" hostname=t137-dut3.openstacklocal addr=? terminal=pts/2 res=success'\",permitted=t,user=\"root\" 1697197701648008589" 1697197770714886723
```

#### Testcase 4 config & output ####
```
[inputs]
[[inputs.t128_tank]]
topic="events"
index_file="/home/centos/test.index"
[outputs]
[[outputs.file]]
files=["/home/centos/tank.txt"]
```
```
[root@t137-dut3 centos]# tail -f tank.txt
t128_tank,host=t137-dut3.openstacklocal,index=588,log_level=debugf message="events,collector_id=auditd,node=westB,subtype=ntp_adjustment,type=system event_detail=\"node=t137-dut3.openstacklocal type=SYSCALL msg=audit(1697216526.571:8918): arch=c000003e syscall=159 success=yes exit=0 a0=5626b096a980 a1=1 a2=0 a3=5626b09fa55c items=0 ppid=1 pid=7236 auid=4294967295 uid=38 gid=38 euid=38 suid=38 fsuid=38 egid=38 sgid=38 fsgid=38 tty=(none) ses=4294967295 comm=\\\"ntpd\\\" exe=\\\"/usr/sbin/ntpd\\\" key=\\\"128T\\\" old_time=2023-10-13T17:02:06.571000Z new_time=2023-10-13T17:02:06Z\",new_date_time=\"2023-10-13T17:02:06Z\",user=\"ntp\" 1697216526571008918" 1697221776118475567
```

```
[root@t137-dut3 centos]# telegraf --config sample.conf
2023-10-13T18:29:31Z I! Starting Telegraf 1.22.10-a05488d6
2023-10-13T18:29:31Z I! Loaded inputs: t128_tank
2023-10-13T18:29:31Z I! Loaded aggregators:
2023-10-13T18:29:31Z I! Loaded processors:
2023-10-13T18:29:31Z I! Loaded outputs: file
2023-10-13T18:29:31Z I! Tags enabled: host=t137-dut3.openstacklocal log_level=debugf
2023-10-13T18:29:31Z I! [agent] Config: Interval:10s, Quiet:false, Hostname:"t137-dut3.openstacklocal", Flush Interval:10s
2023-10-13T18:29:31Z E! [inputs.t128_tank] starting events tank read from index 701
2023-10-13T18:29:31Z E! [inputs.t128_tank] encountered error while parsing lines in events output, will not attempt to parse more lines: parsed boundary fault: next available index is 588
2023-10-13T18:29:31Z E! [inputs.t128_tank] events read routine exited with error: parsed boundary fault: next available index is 588
2023-10-13T18:29:36Z E! [inputs.t128_tank] starting events tank read from index 588
^C2023-10-13T18:30:27Z E! [inputs.t128_tank] events reader done
2023-10-13T18:30:27Z I! [agent] Hang on, flushing any cached metrics before shutdown
2023-10-13T18:30:27Z I! [agent] Stopping running outputs
[root@t137-dut3 centos]#
```

#### Testcase 5 ####

```
systemctl stop tank
```

```
2023-10-13T18:38:12Z E! [inputs.t128_tank] events read routine exited with error: found empty newline in events tank stream, continuing
2023-10-13T18:38:17Z E! [inputs.t128_tank] starting events tank read from index 87
2023-10-13T18:38:17Z E! [inputs.t128_tank] encountered error while parsing lines in events output, will not attempt to parse more lines: found empty newline in events tank stream, continuing
...
...
...
2023-10-13T18:37:32Z E! [inputs.t128_tank] events read routine exited with error: found empty newline in events tank stream, continuing
2023-10-13T18:37:37Z E! [inputs.t128_tank] starting events tank read from index 87
2023-10-13T18:37:37Z E! [inputs.t128_tank] encountered error while parsing lines in events output, will not attempt to parse more lines: found empty newline in events tank stream, continuing
2023-10-13T18:37:37Z E! [inputs.t128_tank] events read routine exited with error: found empty newline in events tank stream, continuing
```

This is what the stdout file stopped at - 

```
t128_tank,host=t137-dut3.openstacklocal,index=631,log_level=debugf message="events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697222201.649:9467): pid=13060 uid=0 auid=1000 ses=92 msg='op=PAM:authentication grantors=pam_rootok acct=\\\"root\\\" exe=\\\"/usr/bin/su\\\" hostname=t137-dut3.openstacklocal addr=? terminal=pts/4 res=success'\",permitted=t,user=\"root\" 1697222201649009467" 1697222322393544749
```

#### Testcase 6 ####

```
systemctl restart tank
```

```
2023-10-13T18:40:56Z E! [inputs.t128_tank] encountered error while parsing lines in events output, will not attempt to parse more lines: found empty newline in events tank stream, continuing
2023-10-13T18:40:56Z E! [inputs.t128_tank] events read routine exited with error: found empty newline in events tank stream, continuing
2023-10-13T18:41:01Z E! [inputs.t128_tank] starting events tank read from index 87
2023-10-13T18:41:01Z E! [inputs.t128_tank] encountered error while parsing lines in events output, will not attempt to parse more lines: parsed boundary fault: next available index is 588
2023-10-13T18:41:01Z E! [inputs.t128_tank] events read routine exited with error: parsed boundary fault: next available index is 588
2023-10-13T18:41:06Z E! [inputs.t128_tank] starting events tank read from index 588
```
Stopped at
```
t128_tank,host=t137-dut3.openstacklocal,index=632,log_level=debugf message="events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697222354.640:9484): pid=14378 uid=0 auid=1000 ses=87 msg='op=PAM:authentication grantors=pam_rootok acct=\\\"root\\\" exe=\\\"/usr/bin/su\\\" hostname=t137-dut3.openstacklocal addr=? terminal=pts/3 res=success'\",permitted=t,user=\"root\" 1697222354640009484" 1697222466531085921
```
Started at after restart
```
t128_tank,host=t137-dut3.openstacklocal,index=633,log_level=debugf message="events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697222526.701:9502): pid=15679 uid=0 auid=1000 ses=87 msg='op=PAM:authentication grantors=pam_rootok acct=\\\"root\\\" exe=\\\"/usr/bin/su\\\" hostname=t137-dut3.openstacklocal addr=? terminal=pts/3 res=success'\",permitted=t,user=\"root\" 1697222526701009502" 1697222526837302373
```

#### Testcase 7 ###

```
systemctl start tank
```

```
t128_tank,host=t137-dut3.openstacklocal,index=632,log_level=debugf message="events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697222354.640:9484): pid=14378 uid=0 auid=1000 ses=87 msg='op=PAM:authentication grantors=pam_rootok acct=\\\"root\\\" exe=\\\"/usr/bin/su\\\" hostname=t137-dut3.openstacklocal addr=? terminal=pts/3 res=success'\",permitted=t,user=\"root\" 1697222354640009484" 1697222354712038750
```

#### Testcase for TagPass ####

#### config without tagpass ####

```
[global_tags]
log_level = "debugf"
[inputs]
[[inputs.t128_tank]]
topic = "session_records"
index_file = "/home/centos/newtest.index"
[outputs]
[[outputs.file]]
files = ["/home/centos/tank.json"]
data_format = "json"
```

#### Output ####

```
{"fields":{"message":"events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697478822.552:10896): pid=6607 uid=0 auid=4294967295 ses=4294967295 msg='op=success acct=\\\"centos\\\" exe=\\\"/usr/sbin/sshd\\\" hostname=? addr=172.18.15.253 terminal=ssh res=success'\",permitted=t,user=\"centos\" 1697478822552010896"},"name":"t128_tank","tags":{"host":"t137-dut3.openstacklocal","index":"897","log_level":"debugf","type":"admin"},"timestamp":1697483882}
{"fields":{"message":"events,collector_id=auditd,node=westB,subtype=ntp_adjustment,type=system event_detail=\"node=t137-dut3.openstacklocal type=SYSCALL msg=audit(1697479334.596:10929): arch=c000003e syscall=159 success=yes exit=0 a0=5626b096a980 a1=1 a2=0 a3=5626b09fa55c items=0 ppid=1 pid=7236 auid=4294967295 uid=38 gid=38 euid=38 suid=38 fsuid=38 egid=38 sgid=38 fsgid=38 tty=(none) ses=4294967295 comm=\\\"ntpd\\\" exe=\\\"/usr/sbin/ntpd\\\" key=\\\"128T\\\" old_time=2023-10-16T18:02:14.596000Z new_time=2023-10-16T18:02:14Z\",new_date_time=\"2023-10-16T18:02:14Z\",user=\"ntp\" 1697479334596010929"},"name":"t128_tank","tags":{"host":"t137-dut3.openstacklocal","index":"898","log_level":"debugf","type":"system"},"timestamp":1697483882}
```

#### config with tagpass ####

```
[global_tags]
log_level = "debugf"
[inputs]
[[inputs.t128_tank]]
topic = "events"
index_file = "/home/centos/newtest.index"
[inputs.t128_tank.tagpass]
type = ["alarm", "admin"]
[outputs]
[[outputs.file]]
files = ["/home/centos/tank.json"]
data_format = "json"
```

#### Output ####

```
{"fields":{"message":"events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697483171.999:11696): pid=7894 uid=0 auid=4294967295 ses=4294967295 msg='op=success acct=\\\"centos\\\" exe=\\\"/usr/sbin/sshd\\\" hostname=? addr=172.18.15.253 terminal=ssh res=success'\",permitted=t,user=\"centos\" 1697483171999011696"},"name":"t128_tank","tags":{"host":"t137-dut3.openstacklocal","index":"928","log_level":"debugf","type":"admin"},"timestamp":1697483995}
{"fields":{"message":"events,collector_id=auditd,node=westB,subtype=authentication,type=admin event_detail=\"node=t137-dut3.openstacklocal type=USER_AUTH msg=audit(1697483837.498:11806): pid=13399 uid=0 auid=4294967295 ses=4294967295 msg='op=pubkey acct=\\\"centos\\\" exe=\\\"/usr/sbin/sshd\\\" hostname=? addr=172.18.15.253 terminal=ssh res=failed'\",fail_reason=\"pubkey\",permitted=f,user=\"centos\" 1697483837498011806"},"name":"t128_tank","tags":{"host":"t137-dut3.openstacklocal","index":"929","log_level":"debugf","type":"admin"},"timestamp":1697483995}
```