### PR TITLE
removed dockerfile as symlink

### DIFF
--- a/.github/actions/Dockerfile
+++ b/.github/actions/Dockerfile
@@ -1,1 +1,34 @@
-../../scripts/ci.docker
+FROM golang:1.18.1
+
+RUN chmod -R 755 "$GOPATH"
+
+RUN DEBIAN_FRONTEND=noninteractive \
+	apt update && apt install -y --no-install-recommends \
+	autoconf \
+	git \
+	libtool \
+	locales \
+	make \
+	awscli \
+	rpm \
+	ruby \
+	ruby-dev \
+	ca-certificates \
+	openssl \
+	zip && \
+	rm -rf /var/lib/apt/lists/*
+
+
+ARG cert_location=/usr/local/share/ca-certificates
+
+# update some certs
+RUN openssl s_client -showcerts -connect github.com:443 </dev/null 2>/dev/null|openssl x509 -outform PEM > ${cert_location}/github.crt
+RUN openssl s_client -showcerts -connect proxy.golang.org:443 </dev/null 2>/dev/null|openssl x509 -outform PEM >  ${cert_location}/proxy.golang.crt
+RUN openssl s_client -showcerts -connect storage.googleapis.com:443 </dev/null 2>/dev/null|openssl x509 -outform PEM >  ${cert_location}/storage.googleapis.crt
+RUN update-ca-certificates
+
+RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+RUN locale-gen C.UTF-8 || true
+ENV LANG=C.UTF-8
+
+RUN gem install fpm


### PR DESCRIPTION
### Description

`Dockerfile` was a symlink that caused RPM creation to fail both locally and on Git Hub. This PR addresses that issue. If required ci.docker could be made into symlink

### Required for all PRs:

- [ ] Signed [CLA](https://influxdata.com/community/cla/).
- [ ] Associated README.md updated.
- [ ] Has appropriate unit tests.

### Screengrabs

###Before the change local testing
```
shriyanshk@shriyanshk-mbp telegraf % docker build -f /Users/shriyanshk/Juniper_Code/telegraf/.github/actions/Dockerfile -t test .
[+] Building 0.0s (2/2) FINISHED                                                                                                                                      docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                  0.0s
 => => transferring dockerfile: 58B                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                                       0.0s
ERROR: failed to solve: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount2055261957/scripts/ci.docker: no such file or directory
```

### After the change local testing

```
docker build .                                                                          
[+] Building 2.1s (14/14) FINISHED                                                                                                                                                     docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.00kB                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.18.1                                                                                                                                       2.1s
 => [ 1/10] FROM docker.io/library/golang:1.18.1....
 => CACHED [ 2/10] RUN chmod -R 755 "/go"                                                                                                                                                              0.0s
 => CACHED [ 3/10] RUN DEBIAN_FRONTEND=noninteractive  apt update && apt install -y --no-install-recommends  autoconf  git  libtool  locales  make  awscli  rpm  ruby  ruby-dev  ca-certificates  ope  0.0s
 => CACHED [ 4/10] RUN openssl s_client -showcerts -connect github.com:443 </dev/null 2>/dev/null|openssl x509 -outform PEM > /usr/local/share/ca-certificates/github.crt                              0.0s
 => CACHED [ 5/10] RUN openssl s_client -showcerts -connect proxy.golang.org:443 </dev/null 2>/dev/null|openssl x509 -outform PEM >  /usr/local/share/ca-certificates/proxy.golang.crt                 0.0s
 => CACHED [ 6/10] RUN openssl s_client -showcerts -connect storage.googleapis.com:443 </dev/null 2>/dev/null|openssl x509 -outform PEM >  /usr/local/share/ca-certificates/storage.googleapis.crt     0.0s
 => CACHED [ 7/10] RUN update-ca-certificates                                                                                                                                                          0.0s
 => CACHED [ 8/10] RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime                                                                                                                               0.0s
 => CACHED [ 9/10] RUN locale-gen C.UTF-8 || true                                                                                                                                                      0.0s
 => CACHED [10/10] RUN gem install fpm                                                                                                                                                                 0.0s
 => exporting to image                                                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                                                0.0s
 => => writing image sha...                                                                                             0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
shriyanshk@shriyanshk-mbp actions % 
```
