### PR TITLE
Added a flag to disable VCS stamping which is preventing release rpm creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ install: $(buildbin)
 $(buildbin):
 	echo $(GOOS)
 	@mkdir -pv $(dir $@)
-	go build -o $(dir $@) -ldflags "$(LDFLAGS)" ./cmd/telegraf
+	go build -o $(dir $@) -ldflags "$(LDFLAGS)" --buildvcs=false ./cmd/telegraf
 
 # Define packages Telegraf supports, organized by architecture with a rule to echo the list to limit include_packages
 # e.g. make package include_packages="$(make amd64)"


### PR DESCRIPTION
### Description ###
This fix is needed because Go 1.18 and above, now embeds version control information in binaries. In order to not provide binaries with Version Control Information, setting this value as false. By default, this is true due to which the rpm creation keeps failing. 

What is VCS?
VCS stamping is the process of adding information about the version control system (VCS) used to manage the project to the binary. It tracks changes to a set of files over time.
