### PR TITLE
TANK track fully processed and pause tank-cli to avoid buffer overflow

### DIFF
--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -80,10 +81,7 @@ func (i index) next() index {
 type CommandContext = func(ctx context.Context, name string, arg ...string) *exec.Cmd
 
 type Reader struct {
-	topic          string
-	lastSavedIndex uint64
-	// used to send events from the read routine to the send routine
-	sendChan chan []IndexedMessage
+	topic string
 	// the target address for the TANK instance
 	tankAddress string
 	// the target port for the TANK instance
@@ -100,15 +98,12 @@ type Reader struct {
 	defaultIndex index
 	// telegraf Logger
 	log telegraf.Logger
-	// telegraf accumulator
-	acc telegraf.Accumulator
 }
 
-func NewReader(tankAddress string, tankPort int, topic string, indexPath string, defaultIndex index, log telegraf.Logger, acc telegraf.Accumulator) *Reader {
+func NewReader(tankAddress string, tankPort int, topic string, indexPath string, defaultIndex index, log telegraf.Logger) *Reader {
 	return &Reader{
 		topic:          topic,
 		tankReadCmdCtx: exec.CommandContext,
-		sendChan:       make(chan []IndexedMessage),
 		readDone:       make(chan error),
 		restartDelay:   5 * time.Second,
 		tankAddress:    tankAddress,
@@ -116,7 +111,6 @@ func NewReader(tankAddress string, tankPort int, topic string, indexPath string,
 		indexPath:      indexPath,
 		defaultIndex:   defaultIndex,
 		log:            log,
-		acc:            acc,
 	}
 }
 
@@ -125,42 +119,71 @@ func (r *Reader) withTankReadCommandContext(tankReadCmdCtx CommandContext) *Read
 	return r
 }
 
-func (r *Reader) Run(mainCtx context.Context) {
-	readCtx, readCtxCancel := context.WithCancel(mainCtx)
+// readSubcmdCtx: the context for the subcommand specifically, not the run loop
+// sendComplete: indices to save - close this channel to complete the run
+func (r *Reader) Run(
+	readSubcmdCtx context.Context,
+	sendChan chan []IndexedMessage,
+	sendComplete <-chan uint64,
+) {
+	var wg sync.WaitGroup
+
 	lastIndex, err := r.getIndex(r.indexPath, r.defaultIndex)
-	r.lastSavedIndex = lastIndex.value
+	lastSavedIndex := lastIndex.value
 	if err != nil {
 		r.log.Errorf("Error in get index %v", err)
-		readCtxCancel()
 		return
 	}
 
 	nextSaveCheck := time.After(2 * time.Second)
+	saveIndex := func() {
+		lastSavedIndex = lastIndex.value
+		r.setIndex(r.indexPath, lastIndex)
+	}
+
 	defer func() {
-		readCtxCancel()
-		r.setIndex(r.indexPath, index{value: r.lastSavedIndex})
+		wg.Wait()
+		saveIndex()
 	}()
 
-	go r.read(readCtx, lastIndex.next())
+	goRead := func(idx index) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.read(readSubcmdCtx, idx, sendChan)
+		}()
+	}
+
+	goRead(lastIndex.next())
 
 	for {
 		select {
-		case <-mainCtx.Done():
-			r.log.Errorf("%s reader done", r.topic)
-			return
 		case <-nextSaveCheck:
-			if lastIndex.value > r.lastSavedIndex {
+			if lastIndex.value > lastSavedIndex {
 				r.setIndex(r.indexPath, lastIndex)
-				r.lastSavedIndex = lastIndex.value
+				lastSavedIndex = lastIndex.value
 			}
 			nextSaveCheck = time.After(2 * time.Second)
+		case completeIndex, ok := <-sendComplete:
+			if !ok {
+				return
+			}
+			lastIndex.value = completeIndex
+			if lastIndex.value%1000 == 0 {
+				saveIndex()
+			}
 		case err := <-r.readDone:
+			// clean exit due to context cancel
+			if err == nil || readSubcmdCtx.Err() != nil {
+				continue
+			}
+
 			var errBoundaryFault *boundaryFault
-			if err != nil && errors.As(err, &errBoundaryFault) {
+			if errors.As(err, &errBoundaryFault) {
 				r.log.Debugf("detected boundary fault, restarting %s tank read from index %d", r.topic, errBoundaryFault.nextAvailableIndex.value)
-				go r.read(readCtx, errBoundaryFault.nextAvailableIndex)
+				goRead(errBoundaryFault.nextAvailableIndex)
 			} else {
-				go r.read(readCtx, lastIndex.next())
+				goRead(lastIndex.next())
 			}
 		}
 	}
@@ -210,13 +233,14 @@ func (r *Reader) setIndex(indexPath string, index index) {
 	}
 }
 
-func (r *Reader) read(readCtx context.Context, startingIndex index) {
+func (r *Reader) read(readCtx context.Context, startingIndex index, sendChan chan []IndexedMessage) {
 	r.log.Infof("starting %s tank read from index %d", r.topic, startingIndex.value)
-	err := r.readFromTank(readCtx, startingIndex)
+	err := r.readFromTank(readCtx, startingIndex, sendChan)
 	if err != nil {
 		r.log.Errorf("%s read routine exited with error: %v", r.topic, err)
 	}
 
+	// we dont want to sleep on context cancel, otherwise shutdown will be slow
 	if readCtx.Err() == nil {
 		time.Sleep(r.restartDelay)
 	}
@@ -224,7 +248,7 @@ func (r *Reader) read(readCtx context.Context, startingIndex index) {
 	r.readDone <- err
 }
 
-func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err error) {
+func (r *Reader) readFromTank(readCtx context.Context, startingIndex index, sendChan chan []IndexedMessage) (err error) {
 	cmdArgs := []string{
 		"/opt/128technology/bin/tank-cli",
 		"-b",
@@ -274,7 +298,7 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 		select {
 		case <-readCtx.Done():
 			return nil
-		case r.sendChan <- collectedMessages:
+		case sendChan <- collectedMessages:
 		}
 	}
 }

--- a/plugins/inputs/t128_tank/t128_tank.go
+++ b/plugins/inputs/t128_tank/t128_tank.go
@@ -6,8 +6,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
 	"github.com/influxdata/telegraf/plugins/inputs"
 	"github.com/influxdata/telegraf/plugins/parsers"
 )
@@ -40,6 +42,14 @@ var sampleConfig = `
 ## first available message in the selected topic. If it is "eof" or "end", 
 ## it will tail the topic for newly produced messages.
 # from = "end"
+
+## Tracking of sent messages allows the input to stop streaming from TANK until
+## existing messages have been processed. This can prevent buffer overflow in
+## telegraf which would drop messages. When batch size or in flight batches is
+## non-zero, all of these tracking fields must be non-zero.
+# tracking_max_in_flight_batches = 0
+# tracking_max_batch_size = 0
+# tracking_max_batch_delay = "1s"
 `
 
 type T128Tank struct {
@@ -50,12 +60,20 @@ type T128Tank struct {
 	SequenceNumberField string `toml:"sequence_number_field"`
 	From                string `toml:"from"`
 
+	TrackingMaxBatches    int             `toml:"tracking_max_in_flight_batches"`
+	TrackingMaxBatchSize  int             `toml:"tracking_max_batch_size"`
+	TrackingMaxBatchDelay config.Duration `toml:"tracking_max_batch_delay"`
+	Precision             config.Duration `toml:"data_precision"`
+
 	Log        telegraf.Logger
 	ctx        context.Context
 	mainWG     sync.WaitGroup
 	cancel     context.CancelFunc
 	parser     parsers.Parser
+	reader     *Reader
 	indexValue index
+
+	adjustTime func(telegraf.Metric)
 }
 
 func (*T128Tank) SampleConfig() string {
@@ -66,14 +84,49 @@ func (*T128Tank) Description() string {
 	return "Run TANK as a long-running input plugin"
 }
 
+type parserWithTimePrecision interface {
+	SetTimePrecision(time.Duration)
+}
+
 func (plugin *T128Tank) SetParser(parser parsers.Parser) {
 	plugin.parser = parser
+	if precisionParser, ok := parser.(parserWithTimePrecision); ok {
+		precisionParser.SetTimePrecision(time.Duration(plugin.Precision))
+	}
 }
 
 func (plugin *T128Tank) Init() error {
 	err := plugin.checkConfig()
 	if err != nil {
 		return err
+	}
+
+	if (plugin.TrackingMaxBatches > 0) != (plugin.TrackingMaxBatchSize > 0) {
+		return fmt.Errorf(
+			"Fields 'tracking_max_in_flight_batches' (%v) and 'tracking_max_batch_size' (%v) must both be zero or non-zero",
+			plugin.TrackingMaxBatches,
+			plugin.TrackingMaxBatchSize,
+		)
+	}
+
+	if plugin.TrackingMaxBatches > 0 && plugin.TrackingMaxBatchDelay <= 0 {
+		return fmt.Errorf("Field 'tracking_max_batch_delay' must be positive when 'tracking_max_in_flight_batches' is non-zero")
+	}
+
+	plugin.reader = NewReader(
+		plugin.ServerAddress,
+		plugin.PortNumber,
+		plugin.Topic,
+		plugin.IndexFile,
+		plugin.indexValue,
+		plugin.Log,
+	)
+
+	if plugin.Precision != config.Duration(time.Nanosecond) {
+		plugin.adjustTime = func(m telegraf.Metric) {
+			adjustedNano := m.Time().UnixNano() * int64(plugin.Precision)
+			m.SetTime(time.Unix(0, adjustedNano))
+		}
 	}
 
 	return nil
@@ -84,16 +137,37 @@ func (plugin *T128Tank) Gather(_ telegraf.Accumulator) error {
 }
 
 func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
+	if plugin.adjustTime == nil {
+		plugin.adjustTime = func(telegraf.Metric) {}
+	}
+
+	if plugin.TrackingMaxBatches > 0 {
+		return plugin.startWithTracking(acc)
+	}
+
+	return plugin.startWithoutTracking(acc)
+}
+
+func (plugin *T128Tank) startWithoutTracking(acc telegraf.Accumulator) error {
 	plugin.ctx, plugin.cancel = context.WithCancel(context.Background())
-	reader := NewReader(plugin.ServerAddress, plugin.PortNumber, plugin.Topic, plugin.IndexFile, plugin.indexValue, plugin.Log, acc)
 	plugin.mainWG.Add(1)
+
 	go func() {
 		defer plugin.mainWG.Done()
+
+		readerBK := &readerBookkeeping{reader: plugin.reader}
+		readerBK.launch(plugin.ctx)
+
 		for {
 			select {
 			case <-plugin.ctx.Done():
+				readerBK.stop()
 				return
-			case messages := <-reader.sendChan:
+			case messages := <-readerBK.sendChan:
+				if len(messages) == 0 {
+					continue
+				}
+
 				for _, message := range messages {
 					metrics, err := plugin.parser.Parse(message.Message)
 					if err != nil {
@@ -103,20 +177,136 @@ func (plugin *T128Tank) Start(acc telegraf.Accumulator) error {
 						if plugin.SequenceNumberField != "" {
 							metric.AddField(plugin.SequenceNumberField, strconv.FormatUint(message.Index.value, 10))
 						}
+						plugin.adjustTime(metric)
 						acc.AddMetric(metric)
 					}
+				}
+				readerBK.sendComplete <- messages[len(messages)-1].Index.value
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (plugin *T128Tank) startWithTracking(ac telegraf.Accumulator) error {
+	plugin.ctx, plugin.cancel = context.WithCancel(context.Background())
+
+	maxTrackedBatches := plugin.TrackingMaxBatches
+	maxBatchSize := plugin.TrackingMaxBatchSize
+	maxBatchDelay := time.Duration(plugin.TrackingMaxBatchDelay)
+
+	acc := ac.WithTracking(maxTrackedBatches)
+	batchTimer := time.NewTicker(maxBatchDelay)
+
+	plugin.Log.Infof("precision is %v", plugin.Precision)
+
+	plugin.mainWG.Add(1)
+	inFlightBatches := map[telegraf.TrackingID]uint64{}
+	go func() {
+		defer plugin.mainWG.Done()
+
+		accumulatingGroup := make([]telegraf.Metric, 0, maxBatchSize)
+		lastAccumulatingIndex := uint64(0)
+
+		readerBK := &readerBookkeeping{reader: plugin.reader}
+		readerBK.launch(plugin.ctx)
+
+		sendBatch := func() {
+			if len(inFlightBatches) >= maxTrackedBatches {
+				readerBK.stop()
+				batchTimer.Reset(maxBatchDelay)
+			}
+
+			trackingID := acc.AddTrackingMetricGroup(accumulatingGroup)
+			inFlightBatches[trackingID] = lastAccumulatingIndex
+			accumulatingGroup = make([]telegraf.Metric, 0, maxBatchSize)
+		}
+
+		for {
+			select {
+			case <-plugin.ctx.Done():
+				readerBK.stop()
+				return
+			case group := <-acc.Delivered():
+				groupID := group.ID()
+				if index, ok := inFlightBatches[groupID]; ok {
+					plugin.Log.Infof("delivered group ID %v with index %v", groupID, index)
+					delete(inFlightBatches, groupID)
+					readerBK.sendComplete <- index
+				}
+				if len(inFlightBatches) == 0 && !readerBK.running {
+					readerBK.relaunch(plugin.ctx)
+				}
+			case messages := <-readerBK.sendChan:
+				for _, message := range messages {
+					metrics, err := plugin.parser.Parse(message.Message)
+					if err != nil {
+						acc.AddError(err)
+					}
+					if len(accumulatingGroup) == 0 {
+						// avoid sending a batch very soon after the first entry is added
+						batchTimer.Reset(maxBatchDelay)
+					}
+					for _, metric := range metrics {
+						plugin.adjustTime(metric)
+					}
+					accumulatingGroup = append(accumulatingGroup, metrics...)
+					if len(accumulatingGroup) >= maxBatchSize {
+						sendBatch()
+					}
+					lastAccumulatingIndex = message.Index.value
+				}
+			case <-batchTimer.C:
+				if len(accumulatingGroup) > 0 {
+					sendBatch()
 				}
 			}
 		}
 	}()
 
-	plugin.mainWG.Add(1)
-	go func() {
-		defer plugin.mainWG.Done()
-		reader.Run(plugin.ctx)
-	}()
-
 	return nil
+}
+
+type readerBookkeeping struct {
+	running bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+	// send processed indices here
+	sendComplete chan uint64
+	sendChan     chan []IndexedMessage
+	reader       *Reader
+}
+
+func (r *readerBookkeeping) relaunch(ctx context.Context) {
+	close(r.sendComplete)
+	close(r.sendChan)
+	r.wg.Wait()
+	r.launch(ctx)
+}
+
+func (r *readerBookkeeping) launch(ctx context.Context) {
+	r.running = true
+	r.ctx, r.cancel = context.WithCancel(ctx)
+	r.wg = sync.WaitGroup{}
+	r.sendChan = make(chan []IndexedMessage)
+	r.sendComplete = make(chan uint64)
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		r.reader.log.Infof("Launching the tank-cli sub-command")
+		r.reader.Run(r.ctx, r.sendChan, r.sendComplete)
+	}()
+}
+
+func (r *readerBookkeeping) stop() {
+	if r.running {
+		r.reader.log.Infof("Stopping the tank-cli sub-command")
+		r.cancel()
+		r.running = false
+	}
 }
 
 func (plugin *T128Tank) Stop() {
@@ -155,8 +345,10 @@ func (plugin *T128Tank) checkConfig() error {
 func init() {
 	inputs.Add("t128_tank", func() telegraf.Input {
 		return &T128Tank{
-			PortNumber:    T128TankPort,
-			ServerAddress: T128TankAddr,
+			PortNumber:            T128TankPort,
+			ServerAddress:         T128TankAddr,
+			TrackingMaxBatchDelay: config.Duration(1 * time.Second),
+			Precision:             config.Duration(1 * time.Nanosecond),
 		}
 	})
 }

--- a/plugins/inputs/t128_tank/t128_tank_test.go
+++ b/plugins/inputs/t128_tank/t128_tank_test.go
@@ -122,6 +122,115 @@ func TestT128TankReader(t *testing.T) {
 	}
 }
 
+func TestT128TankReaderWithTracking(t *testing.T) {
+	testcases := []struct {
+		Name                   string
+		IndexFile              string
+		IndexFileContent       string
+		Topic                  string
+		PortNumber             int
+		ServerAddress          string
+		TankReadCommandContext mockTankCommadContext
+		DefaultIndex           index
+		ExpectedMetrics        []IndexedMessage
+		MaxInFlightBatches     int
+		MaxBatchSize           int
+		MaxBatchDelay          time.Duration
+	}{
+		{
+			Name:          "index file with no value",
+			Topic:         "events",
+			PortNumber:    11011,
+			ServerAddress: "127.0.0.2",
+			DefaultIndex:  StartIndex,
+			TankReadCommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+				cmd := exec.CommandContext(ctx, "echo", "seq=1:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775")
+				return cmd
+			},
+			ExpectedMetrics: []IndexedMessage{
+				{
+					Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
+					Index:   index{value: 1},
+				},
+			},
+		},
+		{
+			Name:             "index file with value",
+			IndexFileContent: "150",
+			Topic:            "events",
+			PortNumber:       11011,
+			ServerAddress:    "127.0.0.2",
+			DefaultIndex:     StartIndex,
+			TankReadCommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+				cmd := exec.CommandContext(ctx, "echo", "seq=150:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775")
+				return cmd
+			},
+			ExpectedMetrics: []IndexedMessage{
+				{
+					Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
+					Index:   index{value: 150},
+				},
+			},
+		},
+	}
+	for _, testcase := range testcases {
+		t.Run(testcase.Name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			var wg sync.WaitGroup
+
+			defer func() {
+				cancel()
+				wg.Wait()
+			}()
+
+			var acc testutil.Accumulator
+			var receivedMessages []IndexedMessage
+
+			indexFileName := strings.ReplaceAll(testcase.Name, " ", "_")
+			if testcase.IndexFileContent != "" {
+				err := os.WriteFile(indexFileName, []byte(testcase.IndexFileContent), 0755)
+				assert.NoError(t, err)
+			}
+
+			plugin := &T128Tank{
+				IndexFile:     indexFileName,
+				Topic:         testcase.Topic,
+				PortNumber:    testcase.PortNumber,
+				ServerAddress: testcase.ServerAddress,
+			}
+
+			reader := NewReader(
+				plugin.ServerAddress,
+				plugin.PortNumber,
+				plugin.Topic,
+				plugin.IndexFile,
+				testcase.DefaultIndex,
+				testutil.Logger{},
+			).withTankReadCommandContext(testcase.TankReadCommandContext)
+
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				reader.Run(ctx)
+			}()
+
+			select {
+			case <-time.After(5 * time.Second):
+				t.Log("no messages received")
+			case <-ctx.Done():
+				t.Log("context canceled")
+			case messages := <-reader.sendChan:
+				receivedMessages = append(receivedMessages, messages...)
+			}
+
+			if len(testcase.ExpectedMetrics) > 0 && receivedMessages != nil {
+				assert.Equal(t, testcase.ExpectedMetrics, receivedMessages)
+
+			}
+		})
+	}
+}
+
 func TestBoundaryFault(t *testing.T) {
 	testcases := []struct {
 		Name                   string


### PR DESCRIPTION
WAN-53918

I believe this is functional, but the performance isn't good enough. See JIRA for description. But I want this closed PR for our records.
