### PR TITLE
Add t128_procstat to testInput diff input condition

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -405,7 +405,7 @@ func (a *Agent) testRunInputs(
 			// Run plugins that require multiple gathers to calculate rate
 			// and delta metrics twice.
 			switch input.Config.Name {
-			case "cpu", "mongodb", "procstat":
+			case "cpu", "mongodb", "procstat", "t128_procstat":
 				nulAcc := NewAccumulator(input, nul)
 				nulAcc.SetPrecision(getPrecision(precision, interval))
 				if err := input.Input.Gather(nulAcc); err != nil {


### PR DESCRIPTION
Bug observed:
t128_procstat does not provide cpu_usage field when run in test mode

Root Cause:
cpu_usage is based on current and previous cpu usage, but in test mode, t128_procstat is only triggered once.

Bug Fix:
add t128_procstat to the case condition in testInput function which would add initialization step for t128_procstat test run.
