### PR TITLE
Add global lock for syslog structured output conversion to avoid bug

### DIFF
--- a/plugins/outputs/syslog/syslog_mapper.go
+++ b/plugins/outputs/syslog/syslog_mapper.go
@@ -6,12 +6,16 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/influxdata/go-syslog/v3/rfc5424"
 
 	"github.com/influxdata/telegraf"
 )
+
+// this is needed until https://github.com/influxdata/go-syslog/pull/51 is released
+var translationMutex sync.Mutex
 
 type SyslogMapper struct {
 	DefaultSdid         string
@@ -56,6 +60,9 @@ func (sm *SyslogMapper) mapStructuredDataItem(key string, value string, msg *rfc
 	if sm.reservedKeys[key] {
 		return
 	}
+
+	translationMutex.Lock()
+	defer translationMutex.Unlock()
 
 	value = escapeInvalidCharacters(value)
 


### PR DESCRIPTION
## Summary
In the go-syslog code, there is global state causing concurrent messages being constructed to occasionally stomp on each other. I'm working on an upstream fix [here](https://github.com/influxdata/go-syslog/pull/51), but in the meantime until that gets published, we want to prevent this from happening.

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.