### PR TITLE
Update t128_graphql to support compound fields

### DIFF
--- a/plugins/inputs/t128_graphql/README.md
+++ b/plugins/inputs/t128_graphql/README.md
@@ -37,6 +37,12 @@ The graphql input plugin collects data from a 128T instance via graphQL.
 #   status = "paths/status"
 #   other = "allRouters/nodes/other-field"  # absolute path
 
+## Optional. Like `extract_fields`, but for use when the data returned for a
+## requested leaf is not a leaf itself. The data below the field will be produced
+## as a JSON string in the field.
+# [inputs.t128_graphql.extract_compound_fields]
+#   addresses = "paths/addresses"
+
 ## The tags for filtering data with the desired name as the key (left) and the graphQL
 ## query path as the value (right). The path can be relative to the entry point or an absolute
 ## path that does not diverge from the entry-point and does not contain graphQL arguments such
@@ -65,6 +71,7 @@ query {
             isActive
             status
             deviceInterface
+            addresses
           }
         }
       }
@@ -92,12 +99,18 @@ For the query above, an example graphQL response is:
                   {
                     "isActive": true,
                     "status": "DOWN",
-                    "deviceInterface": "10"
+                    "deviceInterface": "10",
+                    "addresses": [
+                      "192.168.1.1"
+                    ]
                   },
                   {
                     "isActive": true,
                     "status": "UP",
-                    "deviceInterface": "11"
+                    "deviceInterface": "11",
+                    "addresses": [
+                      "192.168.1.5"
+                    ]
                   }
                 ],
                 "name": "fake"
@@ -116,6 +129,6 @@ For the query above, an example graphQL response is:
 For the response above, the collector outputs:
 
 ```text
-peer-paths,router-name=RTR_EAST_COMBO,device-interface=10,peer-name=fake other="foo",is-active=true,status="DOWN" 1617285085000000000
-peer-paths,router-name=RTR_EAST_COMBO,device-interface=11,peer-name=fake other="foo",is-active=true,status="UP" 1617285085000000000
+peer-paths,router-name=RTR_EAST_COMBO,device-interface=10,peer-name=fake other="foo",is-active=true,status="DOWN",addresses="[\"192.168.1.1\"]" 1617285085000000000
+peer-paths,router-name=RTR_EAST_COMBO,device-interface=11,peer-name=fake other="foo",is-active=true,status="UP",addresses="[\"192.168.1.5\"]" 1617285085000000000
 ```

--- a/plugins/inputs/t128_graphql/config.go
+++ b/plugins/inputs/t128_graphql/config.go
@@ -4,11 +4,12 @@ import (
 	"strings"
 )
 
-//Config stores paths to fields, tags and predicates to be used by BuildQuery and ProcessResponse
+// Config stores paths to fields, tags and predicates to be used by BuildQuery and ProcessResponse
 type Config struct {
-	Predicates map[string]string
-	Fields     map[string]string
-	Tags       map[string]string
+	Predicates     map[string]string
+	Fields         map[string]string
+	CompoundFields map[string]string
+	Tags           map[string]string
 }
 
 /*
@@ -16,11 +17,13 @@ LoadConfig converts a telegraf config into paths to predicates, fields and tags 
 Paths correspond to keys in the output to avoid collisions and because they are used as lookups in ProcessResponse
 
 Args:
+
 	entryPoint example - "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes"
 	fieldsIn example - map[string]string{"test-field": "test-field"}
 	tagsIn example - map[string]string{"test-tag": "test-tag"}
 
 Example:
+
 	For the example input above, LoadConfig() will produce the following Config
 
 	*Config{
@@ -36,6 +39,8 @@ func LoadConfig(
 	entryPoint string,
 	fieldsWithRelPath map[string]string,
 	fieldsWithAbsPath map[string]string,
+	compoundFieldsWithRelPath map[string]string,
+	compoundFieldsWithAbsPath map[string]string,
 	tagsWithRelPath map[string]string,
 	tagsWithAbsPath map[string]string,
 ) *Config {
@@ -59,6 +64,8 @@ func LoadConfig(
 	config.Predicates = predicates
 	config.Fields = formatPaths(fieldsWithRelPath, path)
 	addDataWithAbsPath(config.Fields, fieldsWithAbsPath)
+	config.CompoundFields = formatPaths(compoundFieldsWithRelPath, path)
+	addDataWithAbsPath(config.CompoundFields, compoundFieldsWithAbsPath)
 	config.Tags = formatPaths(tagsWithRelPath, path)
 	addDataWithAbsPath(config.Tags, tagsWithAbsPath)
 
@@ -72,7 +79,7 @@ func addDataWithAbsPath(currentTags map[string]string, tagsWithAbsPath map[strin
 	return currentTags
 }
 
-//needed because users configure tags & fields with paths starting at entry_point with "/" instead of "."
+// needed because users configure tags & fields with paths starting at entry_point with "/" instead of "."
 func formatPaths(items map[string]string, basePath string) map[string]string {
 	newMap := make(map[string]string)
 	replacer := strings.NewReplacer("/", ".")
@@ -82,7 +89,7 @@ func formatPaths(items map[string]string, basePath string) map[string]string {
 	return newMap
 }
 
-//needed to strip whitespace and to replace ' with \"
+// needed to strip whitespace and to replace ' with \"
 func formatPredicate(predicate string) string {
 	replacer := strings.NewReplacer(" ", "", "'", "\"")
 	return replacer.Replace(predicate)

--- a/plugins/inputs/t128_graphql/config_test.go
+++ b/plugins/inputs/t128_graphql/config_test.go
@@ -22,6 +22,7 @@ var JSONPathFormationTestCases = []struct {
 		Name:           "process simple input",
 		EntryPoint:     "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:         getTestFields(),
+		CompoundFields: getTestCompoundFields(),
 		Tags:           getTestTags(),
 		ExpectedOutput: getTestConfigWithPredicates("(name:\"ComboEast\")", "(name:\"east-combo\")"),
 	},
@@ -29,6 +30,7 @@ var JSONPathFormationTestCases = []struct {
 		Name:           "process predicate with list",
 		EntryPoint:     "allRouters(names:['wan','lan'])/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:         getTestFields(),
+		CompoundFields: getTestCompoundFields(),
 		Tags:           getTestTags(),
 		ExpectedOutput: getTestConfigWithPredicates("(names:[\"wan\",\"lan\"])", "(name:\"east-combo\")"),
 	},
@@ -36,6 +38,7 @@ var JSONPathFormationTestCases = []struct {
 		Name:           "process multi-value predicates",
 		EntryPoint:     "allRouters(names:['wan', 'lan'], key2:'value2')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
 		Fields:         getTestFields(),
+		CompoundFields: getTestCompoundFields(),
 		Tags:           getTestTags(),
 		ExpectedOutput: getTestConfigWithPredicates("(names:[\"wan\",\"lan\"],key2:\"value2\")", "(name:\"east-combo\")"),
 	},
@@ -48,6 +51,12 @@ var JSONPathFormationTestCases = []struct {
 		},
 		FieldsWithAbsPath: map[string]string{
 			"other-field": "allServices/nodes/other",
+		},
+		CompoundFields: map[string]string{
+			"compound-field": "compound-field",
+		},
+		CompoundFieldsWithAbsPath: map[string]string{
+			"other-compound-field": "allServices/nodes/other-compound-field",
 		},
 		Tags: getTestTags(),
 		TagsWithAbsPath: map[string]string{
@@ -62,6 +71,10 @@ var JSONPathFormationTestCases = []struct {
 				".data.allServices.nodes.timeSeriesAnalytic.timestamp": "timestamp",
 				".data.allServices.nodes.other":                        "other-field",
 			},
+			CompoundFields: map[string]string{
+				".data.allServices.nodes.timeSeriesAnalytic.compound-field": "compound-field",
+				".data.allServices.nodes.other-compound-field":              "other-compound-field",
+			},
 			Tags: map[string]string{
 				".data.allServices.nodes.timeSeriesAnalytic.test-tag": "test-tag",
 				".data.allServices.nodes.name":                        "name",
@@ -72,6 +85,7 @@ var JSONPathFormationTestCases = []struct {
 		Name:           "process complex config",
 		EntryPoint:     "allRouters(names:['wan', 'lan'], key2:'value2')/nodes/nodes(names:['east-combo', 'west-combo'])/nodes/arp/nodes",
 		Fields:         getTestFields(),
+		CompoundFields: getTestCompoundFields(),
 		Tags:           getTestTags(),
 		ExpectedOutput: getTestConfigWithPredicates("(names:[\"wan\",\"lan\"],key2:\"value2\")", "(names:[\"east-combo\",\"west-combo\"])"),
 	},
@@ -83,8 +97,9 @@ func getTestConfigWithPredicates(pred1 string, pred2 string) *plugin.Config {
 			".data.allRouters.$predicate":             pred1,
 			".data.allRouters.nodes.nodes.$predicate": pred2,
 		},
-		Fields: map[string]string{".data.allRouters.nodes.nodes.nodes.arp.nodes.test-field": "test-field"},
-		Tags:   map[string]string{".data.allRouters.nodes.nodes.nodes.arp.nodes.test-tag": "test-tag"},
+		Fields:         map[string]string{".data.allRouters.nodes.nodes.nodes.arp.nodes.test-field": "test-field"},
+		CompoundFields: map[string]string{".data.allRouters.nodes.nodes.nodes.arp.nodes.test-compound-field": "test-compound-field"},
+		Tags:           map[string]string{".data.allRouters.nodes.nodes.nodes.arp.nodes.test-tag": "test-tag"},
 	}
 }
 
@@ -107,6 +122,10 @@ func TestT128GraphqlEntryPointParsing(t *testing.T) {
 
 func getTestFields() map[string]string {
 	return map[string]string{"test-field": "test-field"}
+}
+
+func getTestCompoundFields() map[string]string {
+	return map[string]string{"test-compound-field": "test-compound-field"}
 }
 
 func getTestTags() map[string]string {

--- a/plugins/inputs/t128_graphql/config_test.go
+++ b/plugins/inputs/t128_graphql/config_test.go
@@ -8,13 +8,15 @@ import (
 )
 
 var JSONPathFormationTestCases = []struct {
-	Name              string
-	EntryPoint        string
-	Fields            map[string]string
-	FieldsWithAbsPath map[string]string
-	Tags              map[string]string
-	TagsWithAbsPath   map[string]string
-	ExpectedOutput    *plugin.Config
+	Name                      string
+	EntryPoint                string
+	Fields                    map[string]string
+	FieldsWithAbsPath         map[string]string
+	CompoundFields            map[string]string
+	CompoundFieldsWithAbsPath map[string]string
+	Tags                      map[string]string
+	TagsWithAbsPath           map[string]string
+	ExpectedOutput            *plugin.Config
 }{
 	{
 		Name:           "process simple input",
@@ -93,6 +95,8 @@ func TestT128GraphqlEntryPointParsing(t *testing.T) {
 				testCase.EntryPoint,
 				testCase.Fields,
 				testCase.FieldsWithAbsPath,
+				testCase.CompoundFields,
+				testCase.CompoundFieldsWithAbsPath,
 				testCase.Tags,
 				testCase.TagsWithAbsPath,
 			)

--- a/plugins/inputs/t128_graphql/query_builder.go
+++ b/plugins/inputs/t128_graphql/query_builder.go
@@ -18,6 +18,7 @@ const (
 BuildQuery first creates an intermediary query object that is traversed by buildQueryBody() in pre-order
 
 Args:
+
 	entryPoint example - "allRouters(name:'ComboEast')/nodes/nodes(name:'combo-east')/nodes/arp/nodes"
 	fields example - map[string]string{"enabled": "enabled"}
 	tags example - map[string]string{
@@ -26,6 +27,7 @@ Args:
 		}
 
 Example:
+
 	For the example input above, buildQueryObject() will produce the following query object
 
 	{
@@ -77,12 +79,13 @@ func BuildQuery(config *Config) string {
 	return query
 }
 
-//buildQueryBody creates an intermediary query object that is traversed by buildQueryBody
+// buildQueryBody creates an intermediary query object that is traversed by buildQueryBody
 func buildQueryObject(config *Config) *gabs.Container {
 	jsonObj := gabs.New()
 
 	addToQueryObj(jsonObj, config.Predicates)
 	addToQueryObj(jsonObj, config.Fields)
+	addToQueryObj(jsonObj, config.CompoundFields)
 	addToQueryObj(jsonObj, config.Tags)
 
 	return jsonObj
@@ -94,7 +97,7 @@ func addToQueryObj(jsonObj *gabs.Container, items map[string]string) {
 	}
 }
 
-//buildQueryBody builds the graphql query body by traversing jsonObj in pre-order and writing to the provided writer
+// buildQueryBody builds the graphql query body by traversing jsonObj in pre-order and writing to the provided writer
 func buildQueryBody(jsonObj *gabs.Container, w io.Writer) {
 	jsonChildren, err := jsonObj.ChildrenMap()
 	if err != nil {

--- a/plugins/inputs/t128_graphql/query_builder_test.go
+++ b/plugins/inputs/t128_graphql/query_builder_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ValidQuerySingleTag   = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"
+	ValidQuerySingleTag   = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-compound-field\ntest-field\ntest-tag}}}}}}}"
 	ValidQueryDoubleTag   = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag-1\ntest-tag-2}}}}}}}"
 	ValidQueryDoubleField = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field-1\ntest-field-2\ntest-tag}}}}}}}"
 	ValidQueryNestedTag   = "query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\nstate{\ntest-tag-2}\ntest-field\ntest-tag-1}}}}}}}"

--- a/plugins/inputs/t128_graphql/response_processor.go
+++ b/plugins/inputs/t128_graphql/response_processor.go
@@ -7,10 +7,11 @@ import (
 	"github.com/Jeffail/gabs"
 )
 
-//ProcessedResponse stores the processed fields and tags for injection into telegraf accumulator
+// ProcessedResponse stores the processed fields and tags for injection into telegraf accumulator
 type ProcessedResponse struct {
-	Fields map[string]interface{}
-	Tags   map[string]string
+	Fields         map[string]interface{}
+	CompoundFields map[string]interface{}
+	Tags           map[string]string
 }
 
 /*
@@ -18,6 +19,7 @@ ProcessResponse takes in a query response, pulls out the desired data and stores
 ProcessResponse traverses the response tree recursively and appropriately merges the data returned by each child.
 
 Args:
+
 	jsonData example - see example below
 	fields example - map[string]string{
 			"/data/allRouters/nodes/peers/nodes/paths/adjacentAddress": "adjacent-address",
@@ -28,6 +30,7 @@ Args:
 		}
 
 Example:
+
 	For the the input given above along with the following jsonData input
 
 	{"data":
@@ -90,11 +93,12 @@ Example:
 	}
 
 Definitions:
+
 	leaf - a single tag/field stored in *ProcessedResponse
 	branch - any *ProcessedResponse that isn't a leaf
 */
-func ProcessResponse(jsonData *gabs.Container, collector string, fields map[string]string, tags map[string]string) ([]*ProcessedResponse, error) {
-	processedResponses := processNode(jsonData, "", fields, tags)
+func ProcessResponse(jsonData *gabs.Container, collector string, fields map[string]string, compoundFields map[string]string, tags map[string]string) ([]*ProcessedResponse, error) {
+	processedResponses := processNode(jsonData, "", fields, compoundFields, tags)
 
 	if len(processedResponses) == 1 && getResponseSize(processedResponses[0]) == 0 {
 		return nil, fmt.Errorf("no data collected for collector %s", collector)
@@ -103,13 +107,22 @@ func ProcessResponse(jsonData *gabs.Container, collector string, fields map[stri
 	return processedResponses, nil
 }
 
-func processNode(jsonData *gabs.Container, path string, fields map[string]string, tags map[string]string) []*ProcessedResponse {
-	processedNode, err := processChildren(jsonData, "map", path, fields, tags)
+func processNode(jsonData *gabs.Container, path string, fields map[string]string, compoundFields map[string]string, tags map[string]string) []*ProcessedResponse {
+	processedNode := []*ProcessedResponse{}
+
+	if _, ok := compoundFields[path]; ok {
+		compoundNode := newResponse()
+		compoundNode.Fields = map[string]interface{}{compoundFields[path]: jsonData.String()}
+		processedNode = append(processedNode, compoundNode)
+		return processedNode
+	}
+
+	processedNode, err := processChildren(jsonData, "map", path, fields, compoundFields, tags)
 	if err == nil {
 		return processedNode
 	}
 
-	processedNode, err = processChildren(jsonData, "list", path, fields, tags)
+	processedNode, err = processChildren(jsonData, "list", path, fields, compoundFields, tags)
 	if err == nil {
 		return processedNode
 	}
@@ -128,11 +141,11 @@ func processNode(jsonData *gabs.Container, path string, fields map[string]string
 	return processedNode
 }
 
-func processChildren(jsonData *gabs.Container, mode string, path string, fields map[string]string, tags map[string]string) ([]*ProcessedResponse, error) {
+func processChildren(jsonData *gabs.Container, mode string, path string, fields map[string]string, compoundFields map[string]string, tags map[string]string) ([]*ProcessedResponse, error) {
 	output := []*ProcessedResponse{}
 
 	processChild := func(child *gabs.Container, path string) {
-		processedChild := processNode(child, path, fields, tags)
+		processedChild := processNode(child, path, fields, compoundFields, tags)
 		for _, mergedChildOutput := range mergeAll(processedChild) {
 			output = append(output, mergedChildOutput)
 		}
@@ -166,9 +179,9 @@ func processChildren(jsonData *gabs.Container, mode string, path string, fields 
 	return processAsList()
 }
 
-//Definitions:
-//leaf - a single tag/field stored in *ProcessedResponse
-//branch - any *ProcessedResponse that isn't a leaf
+// Definitions:
+// leaf - a single tag/field stored in *ProcessedResponse
+// branch - any *ProcessedResponse that isn't a leaf
 func collectLeaf(leaf interface{}, mode string, path string, lookup map[string]string) (*ProcessedResponse, error) {
 	output := newResponse()
 
@@ -185,7 +198,7 @@ func collectLeaf(leaf interface{}, mode string, path string, lookup map[string]s
 	return nil, fmt.Errorf("could not collect leaf")
 }
 
-//merges all leaves/branches at a given node
+// merges all leaves/branches at a given node
 func mergeAll(itemsToMerge []*ProcessedResponse) []*ProcessedResponse {
 	leaves := []*ProcessedResponse{}
 	branches := []*ProcessedResponse{}
@@ -214,7 +227,7 @@ func mergeAll(itemsToMerge []*ProcessedResponse) []*ProcessedResponse {
 	return branches
 }
 
-//used when a node only has leaves
+// used when a node only has leaves
 func mergeLeaves(leaves []*ProcessedResponse) []*ProcessedResponse {
 	mergedLeaves := newResponse()
 	for _, leaf := range leaves {
@@ -231,7 +244,7 @@ func mergeLeaves(leaves []*ProcessedResponse) []*ProcessedResponse {
 	return []*ProcessedResponse{mergedLeaves}
 }
 
-//used when a node has branches and leaves
+// used when a node has branches and leaves
 func mergeLeafIntoBranch(leaf *ProcessedResponse, branch *ProcessedResponse) *ProcessedResponse {
 	newBranch := branch
 	success, err := mergeFields(leaf, newBranch)

--- a/plugins/inputs/t128_graphql/response_processor_test.go
+++ b/plugins/inputs/t128_graphql/response_processor_test.go
@@ -16,6 +16,7 @@ const (
 var ResponseProcessingTestCases = []struct {
 	Name           string
 	Fields         map[string]string
+	CompoundFields map[string]string
 	Tags           map[string]string
 	JsonInput      *gabs.Container
 	ExpectedOutput []*plugin.ProcessedResponse
@@ -427,6 +428,7 @@ func TestT128GraphqlResponseProcessing(t *testing.T) {
 			processedResponse, err := plugin.ProcessResponse(
 				testCase.JsonInput,
 				"test-collector",
+				testCase.CompoundFields,
 				testCase.Fields,
 				testCase.Tags,
 			)

--- a/plugins/inputs/t128_graphql/response_processor_test.go
+++ b/plugins/inputs/t128_graphql/response_processor_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/Jeffail/gabs"
+	"github.com/google/go-cmp/cmp"
 	plugin "github.com/influxdata/telegraf/plugins/inputs/t128_graphql"
 	"github.com/stretchr/testify/require"
 )
@@ -428,13 +429,13 @@ func TestT128GraphqlResponseProcessing(t *testing.T) {
 			processedResponse, err := plugin.ProcessResponse(
 				testCase.JsonInput,
 				"test-collector",
-				testCase.CompoundFields,
 				testCase.Fields,
+				testCase.CompoundFields,
 				testCase.Tags,
 			)
 
 			require.Equal(t, testCase.ExpectedError, err)
-			require.ElementsMatch(t, testCase.ExpectedOutput, processedResponse)
+			require.ElementsMatchf(t, testCase.ExpectedOutput, processedResponse, cmp.Diff(testCase.ExpectedOutput, processedResponse))
 		})
 	}
 }

--- a/plugins/inputs/t128_graphql/t128_graphql.go
+++ b/plugins/inputs/t128_graphql/t128_graphql.go
@@ -34,6 +34,7 @@ type T128GraphQL struct {
 	UnixSocket      string            `toml:"unix_socket"`
 	EntryPoint      string            `toml:"entry_point"`
 	Fields          map[string]string `toml:"extract_fields"`
+	CompoundFields  map[string]string `toml:"extract_compound_fields"`
 	Tags            map[string]string `toml:"extract_tags"`
 	Timeout         config.Duration   `toml:"timeout"`
 	RetryIfNotFound bool              `toml:"retry_if_not_found"`
@@ -68,6 +69,11 @@ func (plugin *T128GraphQL) Init() error {
 		return err
 	}
 
+	compundFieldsWithRelPath, compoundFieldsWithAbsPath, err := validateAndSeparatePaths(plugin.CompoundFields, plugin.EntryPoint)
+	if err != nil {
+		return err
+	}
+
 	tagsWithRelPath, tagsWithAbsPath, err := validateAndSeparatePaths(plugin.Tags, plugin.EntryPoint)
 	if err != nil {
 		return err
@@ -77,6 +83,8 @@ func (plugin *T128GraphQL) Init() error {
 		plugin.EntryPoint,
 		fieldsWithRelPath,
 		fieldsWithAbsPath,
+		compundFieldsWithRelPath,
+		compoundFieldsWithAbsPath,
 		tagsWithRelPath,
 		tagsWithAbsPath,
 	)
@@ -220,7 +228,7 @@ func (plugin *T128GraphQL) MakeRequest() ([]*ProcessedResponse, []error) {
 		errs = append(errs, fmt.Errorf("no data found in response for collector %s", plugin.CollectorName))
 		return nil, errs
 	}
-	processedResponses, err := ProcessResponse(jsonParsed, plugin.CollectorName, plugin.Config.Fields, plugin.Config.Tags)
+	processedResponses, err := ProcessResponse(jsonParsed, plugin.CollectorName, plugin.Config.Fields, plugin.Config.CompoundFields, plugin.Config.Tags)
 	if err != nil {
 		errs = append(errs, err)
 		return nil, errs

--- a/plugins/inputs/t128_graphql/t128_graphql_test.go
+++ b/plugins/inputs/t128_graphql/t128_graphql_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/telegraf"
 	"github.com/influxdata/telegraf/config"
 	plugin "github.com/influxdata/telegraf/plugins/inputs/t128_graphql"
@@ -26,6 +27,7 @@ const (
 	ValidExpectedRequest                  = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"}`
 	ValidExpectedRequestNoTag             = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field}}}}}}}"}`
 	ValidExpectedRequestWithAbsPaths      = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nname\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}\nname}}}}}"}`
+	ValidExpectedRequestWithCompoundField = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nname\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ncompound-field\ntest-field\ntest-tag}}\nname}}}}}"}`
 	ValidExpectedRequestWithMixedResponse = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\nrouter{\npeers(names:\"peer-1\"){\nnodes{\npaths{\nstatus\nuptime}}}}}}}}}"}`
 	InvalidRouterExpectedRequest          = `{"query":"query {\nallRouters(name:\"not-a-router\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ntest-field\ntest-tag}}}}}}}"}`
 	InvalidFieldExpectedRequest           = `{"query":"query {\nallRouters(name:\"ComboEast\"){\nnodes{\nnodes(name:\"east-combo\"){\nnodes{\narp{\nnodes{\ninvalid-field\ntest-tag}}}}}}}"}`
@@ -46,6 +48,7 @@ var CollectorTestCases = []struct {
 	Name             string
 	EntryPoint       string
 	Fields           map[string]string
+	CompoundFields   map[string]string
 	Tags             map[string]string
 	InitError        bool
 	Query            string
@@ -304,6 +307,61 @@ var CollectorTestCases = []struct {
 		ExpectedRequests: []int{1},
 	},
 	{
+		Name:       "compound fields",
+		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/arp/nodes",
+		Fields: map[string]string{
+			"test-field":       "test-field",
+			"other-test-field": "allRouters/nodes/nodes/nodes/name",
+		},
+		CompoundFields: map[string]string{
+			"compound-field": "compound-field",
+		},
+		Tags: map[string]string{
+			"test-tag":       "test-tag",
+			"other-test-tag": "allRouters/nodes/name",
+		},
+		Query: ValidQueryWithAbsPaths,
+		Endpoint: Endpoint{"/api/v1/graphql/", 200, ValidExpectedRequestWithCompoundField, `{
+			"data": {
+				"allRouters": {
+				  	"nodes": [{
+						"name": "ComboEast",
+					  	"nodes": {
+							"nodes": [{
+								"name": "east-combo",
+								"arp": {
+							  		"nodes": [{
+								  		"test-field": 128,
+								  		"test-tag": "test-string-1",
+										"compound-field": {
+											"nested-field": "value"
+										}
+									}]
+								}
+						  	}]
+					  	}
+					}]
+				}
+			}
+		}`},
+		ExpectedMetrics: []*testutil.Metric{
+			{
+				Measurement: "test-collector",
+				Tags: map[string]string{
+					"test-tag":       "test-string-1",
+					"other-test-tag": "ComboEast",
+				},
+				Fields: map[string]interface{}{
+					"test-field":       128.0,
+					"other-test-field": "east-combo",
+					"compound-field":   "{\"nested-field\":\"value\"}",
+				},
+			},
+		},
+		ExpectedErrors:   nil,
+		ExpectedRequests: []int{1},
+	},
+	{
 		Name:       "mixed produces errors and response",
 		EntryPoint: "allRouters(name:'ComboEast')/nodes/nodes(name:'east-combo')/nodes/router/peers(names:'peer-1')/nodes",
 		Fields: map[string]string{
@@ -528,6 +586,7 @@ func TestT128GraphqlCollector(t *testing.T) {
 				BaseURL:         fakeServer.URL + "/api/v1/graphql",
 				EntryPoint:      testCase.EntryPoint,
 				Fields:          testCase.Fields,
+				CompoundFields:  testCase.CompoundFields,
 				Tags:            testCase.Tags,
 				RetryIfNotFound: testCase.RetryIfNotFound,
 			}
@@ -563,8 +622,8 @@ func TestT128GraphqlCollector(t *testing.T) {
 				errorStrings = append(errorStrings, err.Error())
 			}
 
-			require.ElementsMatch(t, testCase.ExpectedErrors, errorStrings)
-			require.ElementsMatch(t, testCase.ExpectedMetrics, acc.Metrics)
+			require.ElementsMatchf(t, testCase.ExpectedErrors, errorStrings, cmp.Diff(testCase.ExpectedErrors, errorStrings))
+			require.ElementsMatchf(t, testCase.ExpectedMetrics, acc.Metrics, cmp.Diff(testCase.ExpectedMetrics, acc.Metrics))
 		})
 	}
 }


### PR DESCRIPTION
## Description


The t128_gaphql telegraf input maps paths from GQL requests to output fields/tags and that mapping is one-to-one. Generally, that is a fair assumption for GQL and we’ve seen other libraries do the same. However, our model has some cases where the data under a request leaf is a tree. We are unable to retrieve such data via the t128_graphql input. We should support a way to get these fields at least as a string JSON blob.

As an example:

```grqphql
    {
      allRouters(name: $routerName) {
        nodes {
          name
          nodes(name: $nodeName) {
            nodes {
              name
              deviceInterfaces(name: $deviceInterface) {
                nodes {
                  extendedStatistics
                }
              }
            }
          }
        }
      }
    }
```

Produces
```json
{
  "data": {
    "allRouters": {
      "nodes": [
        {
          "name": "burl-corp",
          "nodes": {
            "nodes": [
              {
                "name": "burl-corp-primary",
                "deviceInterfaces": {
                  "nodes": [
                    {
                      "extendedStatistics": {
                        "rx_xoff_packets": 0,
                        "rx_jabber_errors": 0,
                        ...
                      }
                    }
                  ]
                }
              }
            ]
          }
        }
      ]
    }
  }
}
```

See the readme and unit test for an example of the output format.