### PR TITLE
added a check for file already closed

### DIFF
--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -140,6 +141,10 @@ func (e *Execd) cmdReadOutStream(out io.Reader) {
 			if err == influx.EOF {
 				break // stream ended
 			}
+			if errors.Is(err, os.ErrClosed) {
+				e.Log.Debugf("stream closed: %w", err)
+				break
+			}
 			if parseErr, isParseError := err.(*influx.ParseError); isParseError {
 				// parse error.
 				e.acc.AddError(parseErr)
@@ -162,6 +167,10 @@ func (e *Execd) cmdReadErr(out io.Reader) {
 	}
 
 	if err := scanner.Err(); err != nil {
+		if errors.Is(err, os.ErrClosed) {
+			e.Log.Debugf("stderr stream closed: %w", err)
+			return
+		}
 		e.acc.AddError(fmt.Errorf("error reading stderr: %w", err))
 	}
 }

--- a/plugins/inputs/execd/execd.go
+++ b/plugins/inputs/execd/execd.go
@@ -142,7 +142,7 @@ func (e *Execd) cmdReadOutStream(out io.Reader) {
 				break // stream ended
 			}
 			if errors.Is(err, os.ErrClosed) {
-				e.Log.Debugf("stream closed: %w", err)
+				e.Log.Debug("ignoring stream closed")
 				break
 			}
 			if parseErr, isParseError := err.(*influx.ParseError); isParseError {
@@ -168,7 +168,7 @@ func (e *Execd) cmdReadErr(out io.Reader) {
 
 	if err := scanner.Err(); err != nil {
 		if errors.Is(err, os.ErrClosed) {
-			e.Log.Debugf("stderr stream closed: %w", err)
+			e.Log.Debug("ignoring stderr: stream closed")
 			return
 		}
 		e.acc.AddError(fmt.Errorf("error reading stderr: %w", err))


### PR DESCRIPTION
### Description
Telegraf is not ensuring the order of operations between waiting on the subprocess and reading from the stdin/stdout pipes of the execd subprocess. We are trying to add the pipe already closed error to be caught in the execd code along with the existing EOF error being caught today.


### Required for all PRs:

- [x] Manual Testing

```
[root@i-00020562 centos]# ./telegraf --config tem.conf --test --debug
2024-07-23T15:21:40Z I! Starting Telegraf
2024-07-23T15:21:40Z I! Loaded inputs: execd
2024-07-23T15:21:40Z I! Loaded aggregators:
2024-07-23T15:21:40Z I! Loaded processors:
2024-07-23T15:21:40Z W! Outputs are not used in testing mode!
2024-07-23T15:21:40Z I! Tags enabled: host=i-00020562
2024-07-23T15:21:40Z D! [agent] Initializing plugins
2024-07-23T15:21:40Z D! [agent] Starting service inputs
2024-07-23T15:21:40Z I! [inputs.execd] Starting process: /usr/bin/cpuStateCollector128t [--summary True --percpu False --unixsocket True --daemon]
2024-07-23T15:21:40Z D! [agent] Stopping service inputs
> cpu-stats,host=i-00020562,type=summary control_utilization=12.6667,data_utilization=0 1721748101051509587
2024-07-23T15:21:41Z D! [inputs.execd] ignoring stream closed
2024-07-23T15:21:41Z D! [inputs.execd] ignoring stderr: stream closed
2024-07-23T15:21:41Z I! [inputs.execd] Process /usr/bin/cpuStateCollector128t shut down
2024-07-23T15:21:41Z D! [agent] Input channel closed
2024-07-23T15:21:41Z D! [agent] Stopped Successfully
```