### PR TITLE
Update the tank reader to better handle FD leaks

### DIFF
--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -260,19 +260,19 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 
 	var parseErr error
 	var messages []*IndexedMessage
-
+parseLoop:
 	for {
 		select {
 		case <-readCtx.Done():
 			r.log.Errorf("%s read routine done", r.topic)
-			return nil
+			break parseLoop
 		default:
 		}
 
 		messages, parseErr = parseLines(tankReader, r.topic)
 		if parseErr != nil {
 			r.log.Errorf("encountered error while parsing lines in %s output, will not attempt to parse more lines: %v", r.topic, parseErr)
-			return parseErr
+			break parseLoop
 		}
 		var collectedMessages []IndexedMessage
 		for _, message := range messages {
@@ -281,10 +281,21 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 		}
 		select {
 		case <-readCtx.Done():
-			return nil
+			break parseLoop
 		case r.sendChan <- collectedMessages:
 		}
+
+		if cmdErr := cmd.Wait(); cmdErr != nil {
+			var exitErr *exec.ExitError
+			if errors.As(cmdErr, &exitErr) {
+				r.log.Errorf("%s tank read command exited with error: %s", r.topic, exitErr.Error())
+			} else {
+				r.log.Errorf("%s tank read command exited with error: %s", r.topic, cmdErr)
+			}
+		}
 	}
+
+	return parseErr
 }
 
 func (i *IndexedMessage) IsValid() bool {

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -272,7 +272,7 @@ parseLoop:
 		messages, parseErr = parseLines(tankReader, r.topic)
 		if parseErr != nil {
 			r.log.Errorf("encountered error while parsing lines in %s output, will not attempt to parse more lines: %v", r.topic, parseErr)
-			break parseLoop
+			return parseErr
 		}
 		var collectedMessages []IndexedMessage
 		for _, message := range messages {
@@ -284,14 +284,13 @@ parseLoop:
 			break parseLoop
 		case r.sendChan <- collectedMessages:
 		}
-
-		if cmdErr := cmd.Wait(); cmdErr != nil {
-			var exitErr *exec.ExitError
-			if errors.As(cmdErr, &exitErr) {
-				r.log.Errorf("%s tank read command exited with error: %s", r.topic, exitErr.Error())
-			} else {
-				r.log.Errorf("%s tank read command exited with error: %s", r.topic, cmdErr)
-			}
+	}
+	if cmdErr := cmd.Wait(); cmdErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(cmdErr, &exitErr) {
+			r.log.Errorf("%s tank read command exited with error: %s", r.topic, exitErr.Error())
+		} else {
+			r.log.Errorf("%s tank read command exited with error: %s", r.topic, cmdErr)
 		}
 	}
 


### PR DESCRIPTION
### Description ###
Updating the error handling tank reader to handle FD leaks better

### Testing ###
#### Before the change ####
This kept on increasing
```
[root@i-000cb472 centos]# ls -l /proc/23838/fd | wc -l
30
[root@i-000cb472 centos]# ls -l /proc/23838/fd
total 0
lrwx------ 1 root root 64 Jan  8 17:45 0 -> /dev/pts/4
lrwx------ 1 root root 64 Jan  8 17:45 1 -> /dev/pts/4
lr-x------ 1 root root 64 Jan  8 17:45 10 -> pipe:[66491592]
lr-x------ 1 root root 64 Jan  8 17:45 11 -> pipe:[66490785]
lr-x------ 1 root root 64 Jan  8 17:45 12 -> pipe:[66490867]
lr-x------ 1 root root 64 Jan  8 17:45 13 -> pipe:[66490972]
lr-x------ 1 root root 64 Jan  8 17:45 14 -> pipe:[66491060]
lr-x------ 1 root root 64 Jan  8 17:45 15 -> pipe:[66491158]
lr-x------ 1 root root 64 Jan  8 17:45 16 -> pipe:[66491228]
lr-x------ 1 root root 64 Jan  8 17:45 17 -> pipe:[66491334]
lr-x------ 1 root root 64 Jan  8 17:45 18 -> pipe:[66494506]
lr-x------ 1 root root 64 Jan  8 17:46 19 -> pipe:[66494582]
lrwx------ 1 root root 64 Jan  8 17:44 2 -> /dev/pts/4
lr-x------ 1 root root 64 Jan  8 17:46 20 -> pipe:[66494647]
lr-x------ 1 root root 64 Jan  8 17:46 21 -> pipe:[66494799]
lr-x------ 1 root root 64 Jan  8 17:46 22 -> pipe:[66494871]
lr-x------ 1 root root 64 Jan  8 17:46 23 -> pipe:[66494949]
lr-x------ 1 root root 64 Jan  8 17:46 24 -> pipe:[66495017]
lr-x------ 1 root root 64 Jan  8 17:46 25 -> pipe:[66495152]
lr-x------ 1 root root 64 Jan  8 17:46 26 -> pipe:[66495249]
lr-x------ 1 root root 64 Jan  8 17:46 27 -> pipe:[66495337]
lr-x------ 1 root root 64 Jan  8 17:46 28 -> pipe:[66495452]
lr-x------ 1 root root 64 Jan  8 17:46 29 -> pipe:[66496610]
lrwx------ 1 root root 64 Jan  8 17:45 3 -> socket:[66484181]
lr-x------ 1 root root 64 Jan  8 17:46 30 -> pipe:[66496661]
lrwx------ 1 root root 64 Jan  8 17:45 4 -> anon_inode:[eventpoll]
lr-x------ 1 root root 64 Jan  8 17:45 5 -> pipe:[66484179]
l-wx------ 1 root root 64 Jan  8 17:45 6 -> pipe:[66484179]
lr-x------ 1 root root 64 Jan  8 17:45 7 -> pipe:[66486157]
lr-x------ 1 root root 64 Jan  8 17:45 8 -> pipe:[66486256]
lr-x------ 1 root root 64 Jan  8 17:45 9 -> pipe:[66490435]
```
#### After the change ####

```
[root@i-000cb472 centos]# ls -l /proc/26223/fd
total 0
lrwx------ 1 root root 64 Jan  8 17:48 0 -> /dev/pts/4
lrwx------ 1 root root 64 Jan  8 17:48 1 -> /dev/pts/4
lrwx------ 1 root root 64 Jan  8 17:48 2 -> /dev/pts/4
lrwx------ 1 root root 64 Jan  8 17:48 3 -> socket:[66515225]
lrwx------ 1 root root 64 Jan  8 17:48 4 -> anon_inode:[eventpoll]
lr-x------ 1 root root 64 Jan  8 17:48 5 -> pipe:[66515224]
l-wx------ 1 root root 64 Jan  8 17:48 6 -> pipe:[66515224]
```
```
[root@i-000cb472 centos]# ls -l /proc/26223/fd | wc -l
8
```