### PR TITLE
Adding cmd.wait to parsing error during tank shutdown

### DIFF
--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -244,7 +244,22 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 		startingIndex.string(),
 	}
 
-	cmd := r.tankReadCmdCtx(readCtx, cmdArgs[0], cmdArgs[1:]...)
+	cmdContext, cmdCancel := context.WithCancel(readCtx)
+
+	cmd := r.tankReadCmdCtx(cmdContext, cmdArgs[0], cmdArgs[1:]...)
+
+	defer func() {
+		cmdCancel()
+		if cmdErr := cmd.Wait(); cmdErr != nil {
+			var exitErr *exec.ExitError
+			if errors.As(cmdErr, &exitErr) {
+				r.log.Errorf("%s tank read command exited with error: %s", r.topic, exitErr.Error())
+			} else {
+				r.log.Errorf("%s tank read command exited with error: %s", r.topic, cmdErr)
+			}
+		}
+	}()
+
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("unable to pipe %s tank output: %s", r.topic, err)
@@ -263,7 +278,7 @@ func (r *Reader) readFromTank(readCtx context.Context, startingIndex index) (err
 parseLoop:
 	for {
 		select {
-		case <-readCtx.Done():
+		case <-cmdContext.Done():
 			r.log.Errorf("%s read routine done", r.topic)
 			break parseLoop
 		default:
@@ -280,17 +295,9 @@ parseLoop:
 			r.lastObservedIndex <- message.Index.value
 		}
 		select {
-		case <-readCtx.Done():
+		case <-cmdContext.Done():
 			break parseLoop
 		case r.sendChan <- collectedMessages:
-		}
-	}
-	if cmdErr := cmd.Wait(); cmdErr != nil {
-		var exitErr *exec.ExitError
-		if errors.As(cmdErr, &exitErr) {
-			r.log.Errorf("%s tank read command exited with error: %s", r.topic, exitErr.Error())
-		} else {
-			r.log.Errorf("%s tank read command exited with error: %s", r.topic, cmdErr)
 		}
 	}
 
@@ -384,3 +391,4 @@ func isBoundaryFault(line string) (bool, index) {
 
 	return true, nextIndex
 }
+


### PR DESCRIPTION
WAN-4028 #time 1h

### Description

Adding `cmd.wait()` to handle FD leaks when parsing error happens due to tank shutdown

### Required for all PRs:

- [x] Signed [CLA](https://influxdata.com/community/cla/).
- [x] Associated README.md updated.
- [x] Has appropriate unit tests.

### Testing 
[Created a new robot test and performed testing](https://github.com/Juniper-SSN/ssr/pull/15900)
```
Verify t128_tank File Descriptior Leak :: Ensure that t128_tank do... | PASS |
------------------------------------------------------------------------------
MonitoringAgentCommands :: Verify the Monitoring Agent's basic com... | PASS |
1 critical test, 1 passed, 0 failed
1 test total, 1 passed, 0 failed
```

<img width="1728" alt="Screenshot 2025-03-19 at 3 31 40 PM" src="https://github.com/user-attachments/assets/4447dc6a-7ffe-4094-8e62-03756a65e396" />


