### PR TITLE
Better handle indexing race condition for OL9

### DIFF
--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -133,25 +133,28 @@ func (r *Reader) Run(mainCtx context.Context) {
 		readCtxCancel()
 		return
 	}
-	r.readDone = make(chan error, 5)
-	r.lastObservedIndex = make(chan uint64, 100)
 
 	var wg sync.WaitGroup
 	nextSaveCheck := time.NewTicker(2 * time.Second)
 	defer func() {
 		readCtxCancel()
-		wg.Wait()
+		go func() {
+			wg.Wait()
+			close(r.lastObservedIndex)
+		}()
 
 		var anyFound bool
 		var lastObservedValue uint64
 	drainLoop:
 		for {
 			select {
-			case observedValue := <-r.lastObservedIndex:
+			case observedValue, ok := <-r.lastObservedIndex:
+				if !ok {
+					break drainLoop
+				}
 				anyFound = true
 				lastObservedValue = observedValue
-			default:
-				break drainLoop
+			case <-r.readDone:
 			}
 		}
 		if anyFound {
@@ -159,7 +162,6 @@ func (r *Reader) Run(mainCtx context.Context) {
 		} else {
 			r.setIndex(r.indexPath, index{value: lastIndex.value})
 		}
-		close(r.lastObservedIndex)
 	}()
 
 	wg.Add(1)

--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/influxdata/telegraf"
@@ -132,28 +133,55 @@ func (r *Reader) Run(mainCtx context.Context) {
 		readCtxCancel()
 		return
 	}
+	r.readDone = make(chan error, 5)
+	r.lastObservedIndex = make(chan uint64, 100)
+
+	var wg sync.WaitGroup
 	nextSaveCheck := time.NewTicker(2 * time.Second)
 	defer func() {
 		readCtxCancel()
-		close(r.lastObservedIndex)
-		observedValue, ok := <-r.lastObservedIndex
-		if ok {
-			r.setIndex(r.indexPath, index{value: observedValue})
+		wg.Wait()
+
+		var anyFound bool
+		var lastObservedValue uint64
+	drainLoop:
+		for {
+			select {
+			case observedValue := <-r.lastObservedIndex:
+				anyFound = true
+				lastObservedValue = observedValue
+			default:
+				break drainLoop
+			}
+		}
+		if anyFound {
+			r.setIndex(r.indexPath, index{value: lastObservedValue})
 		} else {
 			r.setIndex(r.indexPath, index{value: lastIndex.value})
 		}
+		close(r.lastObservedIndex)
 	}()
-	go r.read(readCtx, lastIndex.next())
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.read(readCtx, lastIndex.next())
+	}()
 
 	for {
 		select {
 		case <-mainCtx.Done():
 			r.log.Errorf("%s reader done", r.topic)
 			return
-		case observedValue = <-r.lastObservedIndex:
-			if lastIndex.value%1000 == 0 {
-				r.setIndex(r.indexPath, index{value: lastIndex.value})
+
+		case val := <-r.lastObservedIndex:
+			if val > lastIndex.value {
+				lastIndex.value = val
+				if lastIndex.value%1000 == 0 {
+					r.setIndex(r.indexPath, index{value: lastIndex.value})
+				}
 			}
+
 		case <-nextSaveCheck.C:
 			if observedValue > lastIndex.value {
 				lastIndex.value = observedValue
@@ -165,10 +193,21 @@ func (r *Reader) Run(mainCtx context.Context) {
 			if err != nil && errors.As(err, &errBoundaryFault) {
 				r.log.Debugf("detected boundary fault, restarting %s tank read from index %d", r.topic, errBoundaryFault.nextAvailableIndex.value)
 				lastIndex = errBoundaryFault.nextAvailableIndex
-				go r.read(readCtx, lastIndex)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					r.read(readCtx, lastIndex)
+				}()
 			} else {
+				if observedValue > lastIndex.value {
+					lastIndex.value = observedValue
+				}
 				lastIndex = lastIndex.next()
-				go r.read(readCtx, lastIndex)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					r.read(readCtx, lastIndex)
+				}()
 			}
 		}
 	}
@@ -391,4 +430,3 @@ func isBoundaryFault(line string) (bool, index) {
 
 	return true, nextIndex
 }
-


### PR DESCRIPTION
### Description ###
This change fixes a race condition where lastObservedIndex updates could be lost during shutdown, leading to duplicated message processing. We now reliably track and persist the highest observed index using a buffered channel and wait group, draining it safely before exit. We also added log clarity to aid debugging.

### Testing ###
- [x] Manual Testing

```
[Ember] Starting a TCP to Ember Unix Proxy on port 31337
Validates a Standard Valid Config :: Validate completes with no er... | PASS |
------------------------------------------------------------------------------
Validates a Nonstandard Valid Config :: Validate completes with no... | PASS |
------------------------------------------------------------------------------
Generates a Standard Valid Config :: Generate has no errors and cr... | PASS |
------------------------------------------------------------------------------
Generates a Nonstandard Valid Config :: Generate has no errors and... | PASS |
------------------------------------------------------------------------------
Configures a Standard Valid Config :: Configure has no errors and ... | PASS |
------------------------------------------------------------------------------
Configures a Nonstandard Valid Config :: Configure has no errors a... | PASS |
------------------------------------------------------------------------------
Runs a Standard Test Input :: Test input runs with no errors and p... | PASS |
------------------------------------------------------------------------------
Runs a Nonstandard Test Input :: Test input runs with no errors an... | PASS |
------------------------------------------------------------------------------
Runs a Standard Run Once :: Run once executes with no errors and p... | PASS |
------------------------------------------------------------------------------
Runs a Nonstandard Run Once :: Run once executes with no errors an... | PASS |
------------------------------------------------------------------------------
Produces a Standard Sample Agent Config :: Produces a sample agent... | PASS |
------------------------------------------------------------------------------
Produces a Nonstandard Sample Agent Config :: Produces a sample ag... | PASS |
------------------------------------------------------------------------------
Produces a Standard List of Available Inputs And Outputs :: Lists ... | PASS |
------------------------------------------------------------------------------
Produces a Nonstandard List of Available Inputs And Outputs :: Lis... | PASS |
------------------------------------------------------------------------------
Produces an Example Config for a Standard Input :: Produces a samp... | PASS |
------------------------------------------------------------------------------
Produces an Example Config for a Nonstandard Input :: Produces a s... | PASS |
------------------------------------------------------------------------------
Stops Standard Running Services :: Running services are stopped by... | PASS |
------------------------------------------------------------------------------
Stops Nonstandard Running Services :: Running services are stopped... | PASS |
------------------------------------------------------------------------------
Stops Only Services for Specified Config :: Unrelated services are... | PASS |
------------------------------------------------------------------------------
MA Service Operates On Standard Config :: Unrelated services are l... | PASS |
------------------------------------------------------------------------------
MA Service Runs Agent Setup On Start :: Unrelated services are lef... | PASS |
------------------------------------------------------------------------------
Validates Old Config are Removed :: Validate completes with no errors | PASS |
------------------------------------------------------------------------------
Validates Old Config left With Flag :: Validate completes with no ... | PASS |
------------------------------------------------------------------------------
Verify t128_metrics Sample By Name :: Verifies that the t128_metri... | PASS |
------------------------------------------------------------------------------
Verify t128_metrics configured output :: Verifies the configured o... | PASS |
------------------------------------------------------------------------------
Verify t128_metrics file output :: Verify the t128_metrics configu... | PASS |
------------------------------------------------------------------------------
Verify t128_metrics kafka output :: Verifies the t128_metrics conf... | PASS |
------------------------------------------------------------------------------
Verify Nonstandard kafka output :: Verifies the t128_metrics confi...
| PASS |
------------------------------------------------------------------------------
Verify t128_device_state Executable :: Verifies the t128_device_st... | PASS |
------------------------------------------------------------------------------
Verify t128_device_state Sample By Name :: Verifies that the t128_... | PASS |
------------------------------------------------------------------------------
Verify t128_device_state configured output :: Verifies the configu... | PASS |
------------------------------------------------------------------------------
Verify t128_device_state file output :: Verify the t128_peer_path ... | PASS |
------------------------------------------------------------------------------
Verify t128_device_state kafka output :: Verifies the t128_device_... | PASS |
------------------------------------------------------------------------------
Verify t128_peer_path Executable :: Verifies the t128_peer_path py... | PASS |
------------------------------------------------------------------------------
Verify t128_peer_path Sample By Name :: Verifies that the t128_pee... | PASS |
------------------------------------------------------------------------------
Verify t128_peer_path configured output :: Verifies the configured... | PASS |
------------------------------------------------------------------------------
Verify t128_peer_path file output :: Verify the t128_peer_path con... | PASS |
------------------------------------------------------------------------------
Verify t128_peer_path kafka output :: Verifies the t128_peer_path ... | PASS |
------------------------------------------------------------------------------
Verify t128_top_analytics Executable :: Verifies the t128_top_anal... | PASS |
------------------------------------------------------------------------------
Verify t128_top_analytics Sample By Name :: Verifies that the t128... | PASS |
------------------------------------------------------------------------------
Verify t128_top_analytics configured output :: Verifies the config... | PASS |
------------------------------------------------------------------------------
Verify t128_top_analytics file output :: Verify the t128_top_analy... | PASS |
------------------------------------------------------------------------------
Verify t128_top_analytics kafka output :: Verifies the t128_top_an... | PASS |
------------------------------------------------------------------------------
Verify t128_arp_state Executable :: Verifies the lytics t128_arp_s... | PASS |
------------------------------------------------------------------------------
Verify t128_arp_state Sample By Name :: Verifies that the t128_arp... | PASS |
------------------------------------------------------------------------------
Verify t128_arp_state configured output :: Verifies the configured... | PASS |
------------------------------------------------------------------------------
Verify t128_arp_state file output :: Verify the t128_arp_state con... | PASS |
------------------------------------------------------------------------------
Verify t128_arp_state kafka output :: Verifies the t128_arp_state ... | PASS |
------------------------------------------------------------------------------
Verify t128_graphql Sample By Name :: Verifies that the t128_graph... | PASS |
------------------------------------------------------------------------------
Verify t128_graphql configured output :: Verifies the configured o... | PASS |
------------------------------------------------------------------------------
Verify t128_graphql file output :: Verify the t128_graphql configu... | PASS |
------------------------------------------------------------------------------
Verify t128_graphql kafka output :: Verifies the t128_graphql conf... | PASS |
------------------------------------------------------------------------------
Verify t128_http Sample By Name :: Verifies that the t128_http sam... | PASS |
------------------------------------------------------------------------------
Verify t128_http configured output :: Verifies the configured outp... | PASS |
------------------------------------------------------------------------------
Verify t128_http file output :: Verify the t128_http configured ou... | PASS |
------------------------------------------------------------------------------
Verify t128_http kafka output :: Verifies the t128_http configured... | PASS |
------------------------------------------------------------------------------
Verify t128_cpu Sample By Name :: Verifies that the t128_cpu sampl... | PASS |
------------------------------------------------------------------------------
Verify t128_cpu configured output :: Verifies the configured outpu... | PASS |
------------------------------------------------------------------------------
Verify t128_cpu file output :: Verify the t128_cpu configured outp... | PASS |
------------------------------------------------------------------------------
Verify t128_cpu kafka output :: Verifies the t128_cpu configured o... | PASS |
------------------------------------------------------------------------------
Verify t128_events Sample By Name :: Verifies that the t128_events... | PASS |
------------------------------------------------------------------------------
Verify t128_events file output :: Verify the t128_events configure... | PASS |
------------------------------------------------------------------------------
Verify t128_events kafka output :: Verifies the t128_events config... | PASS |
------------------------------------------------------------------------------
Verify t128_events indexed output :: Verify the t128_events correc... | PASS |
------------------------------------------------------------------------------
Verify t128_tank File Descriptior Leak :: Ensure that t128_tank do... | PASS |
------------------------------------------------------------------------------
Verify t128_events output produces events                             | PASS |
------------------------------------------------------------------------------
```