### PR TITLE
t128_tank: stream from the beginning if parsing the index fails

### DIFF
--- a/plugins/inputs/t128_tank/reader.go
+++ b/plugins/inputs/t128_tank/reader.go
@@ -128,9 +128,7 @@ func (r *Reader) Run(mainCtx context.Context) {
 	var observedValue uint64
 	lastIndex, err := r.getIndex(r.indexPath, r.defaultIndex)
 	if err != nil {
-		r.log.Errorf("Error in get index %v", err)
-		readCtxCancel()
-		return
+		r.log.Infof("Failed to get index %v", err)
 	}
 	nextSaveCheck := time.NewTicker(2 * time.Second)
 	defer func() {

--- a/plugins/inputs/t128_tank/t128_tank_test.go
+++ b/plugins/inputs/t128_tank/t128_tank_test.go
@@ -30,6 +30,7 @@ func TestT128TankReader(t *testing.T) {
 		Name                   string
 		IndexFile              string
 		IndexFileContent       string
+		IndexFileEmpty         bool
 		Topic                  string
 		PortNumber             int
 		ServerAddress          string
@@ -38,11 +39,29 @@ func TestT128TankReader(t *testing.T) {
 		ExpectedMetrics        []IndexedMessage
 	}{
 		{
-			Name:          "index file with no value",
+			Name:          "index file does not exist",
 			Topic:         "events",
 			PortNumber:    11011,
 			ServerAddress: "127.0.0.2",
 			DefaultIndex:  StartIndex,
+			TankReadCommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+				cmd := exec.CommandContext(ctx, "echo", "seq=1:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775")
+				return cmd
+			},
+			ExpectedMetrics: []IndexedMessage{
+				{
+					Message: []byte("measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775"),
+					Index:   index{value: 1},
+				},
+			},
+		},
+		{
+			Name:           "index file empty",
+			Topic:          "events",
+			IndexFileEmpty: true,
+			PortNumber:     11011,
+			ServerAddress:  "127.0.0.2",
+			DefaultIndex:   StartIndex,
 			TankReadCommandContext: func(ctx context.Context, name string, arg ...string) *exec.Cmd {
 				cmd := exec.CommandContext(ctx, "echo", "seq=1:measurement,core=2,node=test-1,port=corp-dmz-p value=0i 1586886775")
 				return cmd
@@ -87,7 +106,7 @@ func TestT128TankReader(t *testing.T) {
 			var wg sync.WaitGroup
 			indexFileName := strings.ReplaceAll(testcase.Name, " ", "_")
 			plugin.IndexFile = path.Join(t.TempDir(), fmt.Sprintf("%s.index", indexFileName))
-			if testcase.IndexFileContent != "" {
+			if testcase.IndexFileContent != "" || testcase.IndexFileEmpty {
 				err := os.WriteFile(plugin.IndexFile, []byte(testcase.IndexFileContent), 0755)
 				assert.NoError(t, err)
 			}
@@ -116,9 +135,12 @@ func TestT128TankReader(t *testing.T) {
 
 			cancel()
 
+			if len(testcase.ExpectedMetrics) > 0 {
+				assert.NotNil(t, receivedMessages)
+			}
+
 			if len(testcase.ExpectedMetrics) > 0 && receivedMessages != nil {
 				assert.Equal(t, testcase.ExpectedMetrics, receivedMessages)
-
 			}
 		})
 	}


### PR DESCRIPTION
I95-62311

## Description

There are a couple cases when reading the index file we might return an error indicating that it failed and why.
1. file doesn't exist isn't an error, but other failures to read are
2. failing to parse the content of the file

The intention here was to provide information, but not to fail. The default index should be used when these errors occur. However, the calling code was written to check for the error and "fail" if observed. Instead, the failure should be logged and the process should continue. The code is updated to behave as described.

Testing: https://github.com/Juniper-SSN/ssr/pull/18009

**The index code for reference:**

```go
func (r *Reader) getIndex(indexPath string, defaultIndex index) (index, error) {
	if indexPath == "" {
		r.log.Debugf("index file path not provided, starting with default index %s", defaultIndex.string())
		return defaultIndex, nil
	}
	content, err := os.ReadFile(indexPath)
	if errors.Is(err, os.ErrNotExist) {
		r.log.Debugf("index file %s does not exist, starting with default index %s", indexPath, defaultIndex.string())
		return defaultIndex, nil

	} else if err != nil {
		return defaultIndex, fmt.Errorf("encountered error reading index file, starting with default index %s: %s", defaultIndex.string(), err)
	}
	newContent := strings.Split(string(content), "\n")[0]
	r.log.Debugf("found '%s' in index file", newContent)
	index, err := newIndex(newContent)
	if err != nil {
		return defaultIndex, fmt.Errorf("encountered error while parsing index file content, starting with default index %s: %s", defaultIndex.string(), err)
	}

	return index, nil
}
```
